### PR TITLE
modules/nixos: implement `homes.<name>.packages`

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -108,13 +108,13 @@
       files = mkOption {
         default = {};
         type = attrsOf (fileType config.directory);
-        description = "";
+        description = "Files to be managed, inserted to relevant systemd-tmpfiles rules";
       };
 
       packages = mkOption {
         type = with lib.types; listOf package;
         default = [];
-        description = "";
+        description = "Packages for ${config.user}";
       };
     };
   };

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -110,6 +110,12 @@
         type = attrsOf (fileType config.directory);
         description = "";
       };
+
+      packages = mkOption {
+        type = with lib.types; listOf package;
+        default = [];
+        description = "";
+      };
     };
   };
 in {
@@ -122,6 +128,11 @@ in {
   };
 
   config = {
+    users.users = mapAttrs' (name: {packages, ...}: {
+      inherit name;
+      value.packages = packages;
+    }) (filterAttrs (_: u: u.packages != []) config.homes);
+
     systemd.user.tmpfiles.users = mapAttrs' (name: {files, ...}: {
       inherit name;
       value.rules = map (


### PR DESCRIPTION
Acts as a consistent interface for 'homes.<name>' to also modify users' packages similar to 'home.packages' that users might be used to. We can map 'homes.<name>.packages' directly to the NixOS option 'users.users.<name>.packages' to replicate the same behaviour without PATH hacks.