### PR TITLE
module/nixos: namespace hjem options

### DIFF
--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         system:
           - x86_64-linux
-          - aarch64-linux
+        test:
+          - hjem-basic
 
     runs-on: ubuntu-latest
     steps:
@@ -34,8 +35,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # For now, only a basic test exists and thus we only build that. In the future
-      # we may consider chaining matrix.system and matrix.check to build more tests
-      # for each individual system.
       - name: Build packages
-        run: nix build -L .#checks.${{ matrix.system }}.hjem-basic -v
+        run: nix build -L .#checks.${{ matrix.system }}.${{ matrix.test }} -v

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ may use to manage individual users' homes by leveraging the module system.
 
 ```nix
 {
-  homes = {
+  hjem.users = {
     alice.files = {
       # Write a text file in `/homes/alice/.config/foo`
       # with the contents bar
@@ -50,10 +50,10 @@ may use to manage individual users' homes by leveraging the module system.
 }
 ```
 
-Each attribute under `homes`, e.g., `homes.alice` and `homes.jane` represent a
-user managed via `users.users` in NixOS. If a user does not exist, then Hjem
-will refuse to manage their `$HOME` by filtering non-existent users in file
-creation.
+Each attribute under `hjem.users`, e.g., `hjem.users.alice` or `hjem.users.jane`
+represent a user managed via `users.users` in NixOS. If a user does not exist,
+then Hjem will refuse to manage their `$HOME` by filtering non-existent users in
+file creation.
 
 ## Module Interface
 
@@ -65,7 +65,7 @@ they see fit.
 Below is a live implementation of the module.
 
 ```nix
-nix-repl> :p nixosConfigurations."nixos".config.homes
+nix-repl> :p nixosConfigurations."nixos".config.hjem.users
 {
   alice = {
     directory = "/home/alice";
@@ -107,7 +107,7 @@ iterations.
 
 ### Manifest & Cleaning up dangling files
 
-The systemd-tmpfiles module lacks a good way of cleaning up dangling lists,
+The systemd-tmpfiles module lacks a good way of cleaning up dangling files,
 e.g., from files that are no longer linked. To tackle this problem, a _manifest_
 of files can be used to diff said manifest during switch and remove files that
 are no longer managed.
@@ -128,7 +128,7 @@ module system exposes the files configuration to a package user provides.
 
 Special thanks to [Nixpkgs](https://github.com/nixOS/nixpkgs) and
 [Home-Manager](https://github.com/nix-community/home-manager). The interface of
-the `homes` module is inspired by Home-Manager's `home.file` and nixpkgs'
+the `hjem.users` module is inspired by Home-Manager's `home.file` and nixpkgs'
 `users.users` modules. Hjem would not be possible without any of those projects.
 
 ## License

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   inherit (lib.modules) mkIf mkDefault mkDerivedConfig;
-  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.options) mkOption mkEnableOption literalMD;
   inherit (lib.strings) hasPrefix;
   inherit (lib.lists) filter map;
   inherit (lib.attrsets) filterAttrs mapAttrs' attrValues;
@@ -26,6 +26,7 @@
         enable = mkOption {
           type = bool;
           default = true;
+          example = false;
           description = ''
             Whether this file should be generated. This option allows specific
             files to be disabled.
@@ -70,11 +71,13 @@
 
         clobber = mkOption {
           type = bool;
-          default = false;
-          example = true;
+          default = cfg.clobberByDefault;
+          defaultText = literalMD "Set to the value of {option}`hjem.clobberByDefault`";
           description = ''
-            Whether to "clobber" existing target paths. While `true`, tmpfile rules will be constructed
-            with `L+` (*re*create) instead of `L` (create) type.
+            Whether to "clobber", i.e., override existing target paths.
+
+            While `true`, tmpfile rules will be constructed with `L+`
+            (*re*create) instead of `L` (create) type.
           '';
         };
 
@@ -144,6 +147,17 @@ in {
   ];
 
   options.hjem = {
+    clobberByDefault = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        The default override behaviour for files managed by Hjem.
+
+        While `true`, existing files will be overriden with new
+        files on rebuild.
+      '';
+    };
+
     users = mkOption {
       default = {};
       type = attrsOf (submodule userOpts);

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   inherit (lib.modules) mkIf mkDefault mkDerivedConfig;
-  inherit (lib.options) mkOption mkEnableOption literalMD;
+  inherit (lib.options) mkOption mkEnableOption literalExpression;
   inherit (lib.strings) hasPrefix;
   inherit (lib.lists) filter map;
   inherit (lib.attrsets) filterAttrs mapAttrs' attrValues;
@@ -72,7 +72,7 @@
         clobber = mkOption {
           type = bool;
           default = cfg.clobberByDefault;
-          defaultText = literalMD "Set to the value of {option}`hjem.clobberByDefault`";
+          defaultText = literalExpression "config.hjem.clobberByDefault";
           description = ''
             Whether to "clobber", i.e., override existing target paths.
 

--- a/tests/basic.nix
+++ b/tests/basic.nix
@@ -18,7 +18,7 @@ in
           password = "";
         };
 
-        homes = {
+        hjem.users = {
           alice = {
             enable = true;
             packages = [pkgs.hello];


### PR DESCRIPTION
- **modules/nixos: move Hjem options under the `hjem` namespace**
- **modules/nixos: add `hjem.clobberByDefault`**
- **docs: update README according to the new namespace changes**

Moves `homes` to `hjem.users` to allow defining more ergonomically, and to avoid
ambiguous behaviour.

Added a rename, but it should be removed in the future.
