### PR TITLE
modules/nixos: add systemd services

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -25,7 +25,7 @@
     modules = concatLists [
       [
         ({name, ...}: {
-          imports = [../common.nix];
+          imports = [../common.nix ./systemd.nix];
 
           config = {
             user = config.users.users.${name}.name;

--- a/modules/nixos/systemd.nix
+++ b/modules/nixos/systemd.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  pkgs,
+  osConfig,
+  config,
+  ...
+}: let
+  inherit (lib.attrsets) nameValuePair mapAttrs';
+  inherit (lib.options) mkOption;
+
+  utils = import "${pkgs.path}/nixos/lib/utils.nix" {
+    inherit lib pkgs;
+    config = osConfig;
+  };
+
+  inherit (utils) systemdUtils;
+  inherit (systemdUtils.lib) generateUnits serviceToUnit;
+
+  cfg = config.systemd;
+in {
+  options.systemd = {
+    services = mkOption {
+      default = {};
+      type = systemdUtils.types.services;
+      description = "Definition of systemd per-user service units.";
+    };
+    units = mkOption {
+      description = "Definition of systemd per-user units.";
+      default = {};
+      type = systemdUtils.types.units;
+    };
+  };
+
+  config = {
+    systemd.units = mapAttrs' (n: v: nameValuePair "${n}.service" (serviceToUnit v)) cfg.services;
+    files.".config/systemd/user".source = generateUnits {
+      type = "user";
+      inherit (cfg) units;
+      upstreamUnits = []; # this is already done in the NixOS module
+      upstreamWants = []; # same here
+      packages = []; # unnecessary, we're using `generateUnits` at user level (no need for hooks or units for now)
+      inherit (osConfig.systemd) package;
+    };
+  };
+}


### PR DESCRIPTION
This adds systemd services configuration through hjem, under `users.<username>.systemd.services`. So far, only defining services in accordance with RFC42 and creating files/mapping them to their correct location is implemented. Closes #17 

I did not manage/have time to handle automatically reloading services via some sort of mechanism ("master" service, shell script etc.). I was wondering how we wanted to approach this/if it's something we want to do.

I know NixOS services configured through the modules have an option called [systemd.user.services.<name>.reloadTriggers](https://search.nixos.org/options?channel=unstable&show=systemd.user.services.%3Cname%3E.reloadTriggers&from=0&size=50&sort=relevance&type=packages&query=reloadTriggers), which might be something we want in hjem, but I'm not sure how we could implement this.