### PR TITLE
modules/common: allow absol. paths within the configured home dir

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -37,8 +37,11 @@
         target = mkOption {
           type = str;
           apply = p:
-            if hasPrefix "/" p
-            then throw "This option cannot handle absolute paths yet!"
+          # check for the / here too, to avoid allowing /home/username<jibberish>/
+            if hasPrefix "${config.relativeTo}/" p
+            then p
+            else if hasPrefix "/" p
+            then throw "This path is outside the user's home directory!"
             else "${config.relativeTo}/${p}";
           defaultText = "name";
           description = ''


### PR DESCRIPTION
Mostly useful for #26.

Tested on top of that PR and also on main, both functioned fine. hjem correctly created the symlinks when the path was within the configured home directory, and if not failed. Updated the error message to reflect this change