### PR TITLE
modules/nixos: remove symlink default permissions

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -20,8 +20,6 @@
   linker = getExe cfg.linker;
 
   manifests = let
-    defaultFilePerms = "644";
-
     mapFiles = _: files:
       lib.attrsets.foldlAttrs (
         accum: _: value:
@@ -32,7 +30,6 @@
             ++ lib.singleton {
               type = "symlink";
               inherit (value) source target;
-              permissions = defaultFilePerms;
             }
       ) []
       files;


### PR DESCRIPTION
Apologies for the oversight! This simply removes the permissions part of the manifest logic, as symlinks just take the permissions of whichever file they're pointing to.