### PR TITLE
meta: cleanup after manifest merge

### DIFF
--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -5,8 +5,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches:
-      - main
+    branches: [main]
 jobs:
   vm-tests:
     if: github.event.pull_request.draft == false
@@ -25,6 +24,12 @@ jobs:
           - os: ubuntu-22.04-arm
             system: "aarch64-linux"
             test: hjem-special-args
+          - os: ubuntu-latest
+            system: "x86_64-linux"
+            test: hjem-linker
+          - os: ubuntu-22.04-arm
+            system: "aarch64-linux"
+            test: hjem-linker
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,9 @@
     nixpkgs,
     ...
   } @ inputs: let
+    # We should only specify the modules Hjem explicitly supports, or we risk
+    # allowing not-so-defined behaviour. For example, adding nix-systems should
+    # be avoided, because it allows specifying Hjem is not tested on.
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
   in {
     nixosModules = {
@@ -19,18 +22,27 @@
       default = self.nixosModules.hjem;
     };
 
+    packages = forAllSystems (system: {
+      # Expose the 'smfh' instance used by Hjem as a package in the Hjem flake
+      # outputs. This allows consuming the exact copy of smfh used by Hjem.
+      smfh = inputs.smfh.packages.${system}.smfh;
+    });
+
     checks = forAllSystems (system: let
       checkArgs = {
         inherit self inputs;
         pkgs = nixpkgs.legacyPackages.${system};
       };
     in {
+      # Build the 'smfh' package as a part of Hjem's test suite.
+      # If 'nix flake check' is ran in the CI, this might inflate build times
+      # *a lot*.
+      inherit (self.packages.${system}) smfh;
+
+      # Hjem Integration Tests
       hjem-basic = import ./tests/basic.nix checkArgs;
       hjem-special-args = import ./tests/special-args.nix checkArgs;
       hjem-linker = import ./tests/linker.nix checkArgs;
-
-      # Build smfh as a part of 'nix flake check'
-      smfh = inputs.smfh.packages.${system}.smfh;
     });
 
     devShells = forAllSystems (system: let


### PR DESCRIPTION
- **flake: export smfh package as an output**
- **ci: build linker tests in GHA**

Exports the synced smfh package as a flake output for users who want to consume
the exact same version as Hjem. Additionally, adds linker tests to the test
workflow.
