### PR TITLE
modules/nixos: adjusted targets for alternative linkers to after local-fs.target

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -239,7 +239,8 @@ in {
       */
       systemd.targets.hjem = {
         description = "Hjem File Management";
-        requiredBy = ["sysinit-reactivation.target"];
+        after = ["local-fs.target"];
+        wantedBy = ["sysinit-reactivation.target" "multi-user.target"];
         before = ["sysinit-reactivation.target"];
         requires = let
           requiredUserServices = name: [


### PR DESCRIPTION
The new linker (via smfh) was failing to run and not showing any info on the journal.  This was likely from it running too soon.  I adjusted the service unit to run after `local-fs.target` to ensure it didn't too soon.

I tested on 2 systems:

* x86_64-linux **with** Impermanence
* x86_64-linux **without** Impermanence

Both had issues and the changes cleared the issues with an identical experience on both. 