### PR TITLE
feat: added wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,22 +40,40 @@ may use to manage individual users' homes by leveraging the module system.
 ```nix
 {
   hjem.users = {
-    alice.files = {
-      # Write a text file in `/homes/alice/.config/foo`
-      # with the contents bar
-      ".config/foo".text = "bar";
+    alice = {
+      files = {
+        # Write a text file in `/homes/alice/.config/foo`
+        # with the contents bar
+        ".config/foo".text = "bar";
 
-      # Alternatively, create the file source using a writer.
-      # This can be used to generate config files with various
-      # formats expected by different programs.
-      ".config/bar".source = pkgs.writeTextFile "file-foo" "file contents";
+        # Alternatively, create the file source using a writer.
+        # This can be used to generate config files with various
+        # formats expected by different programs.
+        ".config/bar".source = pkgs.writeTextFile "file-foo" "file contents";
 
-      # You can also use generators to transform Nix values
-      ".config/baz" = {
-        # Works with `pkgs.formats` too!
-        generator = lib.generators.toJSON { };
-        value = {
-          some = "contents";
+        # You can also use generators to transform Nix values
+        ".config/baz" = {
+          # Works with `pkgs.formats` too!
+          generator = lib.generators.toJSON { };
+          value = {
+            some = "contents";
+          };
+        };
+      };
+
+      wrappers = {
+        # Creates a wrapper around `baz` with the environment variable
+        # `BAZ_CONFIG` set to a nix-store path.
+        "baz" = {
+          basePackage = pkgs.baz;
+          environment."BAZ_CONFIG".value = self + "/path/to/baz.config";
+        };
+
+        # Creates a wrapper around `buz` with the command line flag `--config`
+        # pointing to a path in the nix-store.
+        "buz" = {
+          basePackage = pkgs.baz;
+          args.suffix = [ "--config ${self + "/path/to/buz.config"}" ];
         };
       };
     };

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -8,13 +8,13 @@
   lib,
   ...
 }: let
-  inherit (lib.attrsets) mapAttrsToList;
+  inherit (lib.attrsets) attrsToList mapAttrsToList;
   inherit (lib.strings) concatLines concatMapStringsSep;
   inherit (lib.modules) mkDefault mkDerivedConfig mkIf mkMerge;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
-  inherit (lib.strings) hasPrefix;
+  inherit (lib.strings) hasPrefix optionalString;
   inherit (lib.types) addCheck anything attrsOf bool either functionTo int lines listOf nullOr package path str submodule oneOf;
-  inherit (builtins) isList;
+  inherit (builtins) foldl' isList;
 
   cfg = config;
 
@@ -141,6 +141,141 @@
           })
         ];
     });
+
+  environmentType = submodule {
+    options = {
+      value = mkOption {
+        type = str;
+        default = "";
+        description = "Set the value of the environment variable.";
+      };
+
+      default = mkOption {
+        type = str;
+        default = "";
+        description = "Set the value of the environment variable if not already set.";
+      };
+
+      unset = mkOption {
+        type = bool;
+        default = false;
+        description = "Whether to unset the environment variable.";
+      };
+
+      delimiter = mkOption {
+        type = str;
+        default = ":";
+        description = "Delimiter used for environment variables which are lists.";
+      };
+
+      prefix = mkOption {
+        type = listOf str;
+        default = [];
+        description = "Prepend value to the environment variable list.";
+      };
+
+      suffix = mkOption {
+        type = listOf str;
+        default = [];
+        description = "Append value to the environment variable list.";
+      };
+    };
+  };
+
+  wrapperType = submodule ({ config, ... }: {
+    options = {
+      basePackage = mkOption {
+        type = package;
+        description = "Package being wrapped";
+      };
+
+      executable = mkOption {
+        type = str;
+        description = "File to be executed";
+
+        # Assuming for most packages, the executable is the name of the package
+        default = config.basePackage.pname;
+      };
+
+      finalPackage = mkOption {
+        type = package;
+        description = "Output derivation containing the wrapper of the package.";
+        readOnly = true;
+        default =
+          pkgs.symlinkJoin {
+            name = "${config.basePackage.name}-hjemWrapped";
+            paths = [ config.basePackage ] ++ config.extraPackages;
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            postBuild =
+              let
+                envPairs = attrsToList config.environment;
+
+                listToSepString = delimiter: xs: foldl' (a: x: "${a}${delimiter}${x}") "" xs;
+                envFlag = n: v:
+                  if (v.value != "") then
+                    "--set ${n} ${v.value}"
+                  else if (v.default != "") then
+                    "--set-default ${n} ${v.default}"
+                  else if v.unset then
+                    "--unset ${n}"
+                  else if (v.prefix != []) then
+                    "--prefix ${n} ${v.delimiter} ${listToSepString v.delimiter v.prefix}"
+                  else if (v.suffix != []) then
+                    "--suffix ${n} ${v.delimiter} ${listToSepString v.delimiter v.suffix}"
+                  else
+                    ""
+                  ;
+              in
+                ''
+                  wrapProgram $out/bin/${config.executable} \
+                    ${optionalString (config.directory != null) "--chdir ${config.directory}"} \
+                    ${foldl' (a: x: "${a} --run ${x}") "" config.run} \
+                    ${foldl' (a: x: "${a} --add-flag ${x}") "" config.args.prefix} \
+                    ${foldl' (a: x: "${a} --append-flag ${x}") "" config.args.suffix} \
+                    ${foldl' (a: x: "${a} ${envFlag x.name x.value}") "" envPairs} \
+                '';
+          };
+      };
+
+      directory = mkOption {
+        type = nullOr path;
+        default = null;
+        description = "Change the directory of the package's environment.";
+      };
+
+      extraPackages = mkOption {
+        type = listOf package;
+        default = [];
+        description = "Additional packages needed in the wrapper's environment $PATH.";
+      };
+
+      run = mkOption {
+        type = listOf str;
+        default = [];
+        description = "Commands to run before the execution of the program";
+      };
+
+      args = {
+        prefix = mkOption {
+          type = listOf str;
+          default = [];
+          description = "Arguments to prepend to the beginning of the wrapped program's arguments.";
+        };
+
+        suffix = mkOption {
+          type = listOf str;
+          default = [];
+          description = "Arguments to append to the end of the wrapped program's arguments.";
+        };
+      };
+
+      environment = mkOption {
+        type = attrsOf environmentType;
+        default = {};
+        description = "Manage the wrapper's environment variables.";
+      };
+    };
+  });
 in {
   imports = [
     # Makes "assertions" option available without having to duplicate the work
@@ -221,6 +356,13 @@ in {
           characters.
         '';
       };
+    };
+
+    wrappers = mkOption {
+      type = attrsOf wrapperType;
+      default = {};
+      example = {};
+      description = "Wrappers to be managed by Hjem.";
     };
   };
 

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -170,7 +170,10 @@ in {
 
   config = mkMerge [
     {
-      users.users = (mapAttrs (_: v: {inherit (v) packages;})) enabledUsers;
+      users.users = let
+        wrapperPackages = user: attrValues (mapAttrs (_: v: v.finalPackage) user.wrappers);
+      in mapAttrs (_: v: { packages = v.packages ++ wrapperPackages v; }) enabledUsers;
+
       assertions =
         concatLists
         (mapAttrsToList (user: config:


### PR DESCRIPTION
## Summary

### Description

This feature provides a **thin** and simple abstraction over wrapProgram which allows the user to:
- configure the base package to wrap
- configure which executable in the package to wrap
- access the final package of the wrapper
- change the directory the program thinks it is being ran in
- add extra packages to the wrapper's runtime
- configure commands to be ran after the wrapper's execution
- prepend and append command line arguments
- set or unset variables (and set only if unset)
- prefix and suffix delimited lists with a list of values and a configurable delimiter

### Changes

- added options for the wrapper abstraction
- introduced wrapper and environment submodule types
- modified how user packages are set to include wrappers
- added minimal example to README

### Checklist

- [x] Code builds and tested locally (now using in prod environments)
- [x] All existing tests pass
- [ ] New tests (I'll add these in subsequent PRs. I think there will be a lot of discussion about this PR already and the tests will likely have some discussion on their own)
- [x] Follows project conventions

### Motivation

To keep nix's purity, reproducibility, and declarative nature, I've integrated `wrapProgram` into `hjem` so that programs can be configured by changing XDG desktop variables, program specific configuration variables, or command line flags to point to the nix store. However, this is not always possible because programs do not always respect XDG desktop variables or provide configuration variables or command line flags as alternatives.

Managing configurations via file-system mutation and effects outside the nix-store, like in home-manager, is not always ideal. But it is sometimes necessary due to wrappers not being possible to properly configure a specific program.

So I think it is a good middle ground for user orchestration is if a tool had both wrapper integration *and* file linking with proper clean up (like removing dead links no longer in the configuration) as is planned in hjem.

### Alternatives

One could create wrappers manually per usual. Although, this has a lot of boilerplate involved and is a bit obtuse or complicated for new users. Also, without some sort of abstraction, it would not be possible to have some sort repository of modules abstracting over different programs.

One could use wrapper-manager. However, it is not *per-user* and some of the options are not very convenient. Also, the codebase is very complex and difficult to understand with loads of hacks. It is also less useful to those wanting to build modules on top of the abstraction like how `hjem-rum` is to `hjem`.

### Other Concerns

If this PR gets merged, I would like to continue maintaining this part of hjem. If not, I'll probably just maintain this in my own personal fork as I still find it useful and nice to use. It's kind of a make or break for me as I find myself using the wrapper part more than the linker.