### PR TITLE
feat: xdg management

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
       hjem-special-args = import ./tests/special-args.nix checkArgs;
       hjem-linker = import ./tests/linker.nix checkArgs;
       hjem-xdg = import ./tests/xdg.nix checkArgs;
+      hjem-xdg-linker = import ./tests/xdg-linker.nix checkArgs;
     });
 
     devShells = forAllSystems (system: let

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
       hjem-basic = import ./tests/basic.nix checkArgs;
       hjem-special-args = import ./tests/special-args.nix checkArgs;
       hjem-linker = import ./tests/linker.nix checkArgs;
+      hjem-xdg = import ./tests/xdg.nix checkArgs;
     });
 
     devShells = forAllSystems (system: let

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -190,8 +190,6 @@ in {
     };
 
     xdg = {
-      enable = mkEnableOption "XDG management for this user";
-
       cache = {
         home = mkOption {
           type = path;
@@ -202,7 +200,7 @@ in {
             {option}`hjem.users.<name>.xdg.cache.files` will be relative to by default.
 
             Adds {env}`XDG_CACHE_HOME` to {option}`environment.sessionVariables` for
-            this user if {option}`xdg.enable` is `true`.
+            this user if changed.
           '';
         };
         files = mkOption {
@@ -223,7 +221,7 @@ in {
             {option}`hjem.users.<name>.xdg.config.files` will be relative to by default.
 
             Adds {env}`XDG_CONFIG_HOME` to {option}`environment.sessionVariables` for
-            this user if {option}`xdg.enable` is `true`.
+            this user if changed.
           '';
         };
         files = mkOption {
@@ -244,7 +242,7 @@ in {
             {option}`hjem.users.<name>.xdg.data.files` will be relative to by default.
 
             Adds {env}`XDG_DATA_HOME` to {option}`environment.sessionVariables` for
-            this user if {option}`xdg.enable` is `true`.
+            this user if changed.
           '';
         };
         files = mkOption {
@@ -265,7 +263,7 @@ in {
             {option}`hjem.users.<name>.xdg.state.files` will be relative to by default.
 
             Adds {env}`XDG_STATE_HOME` to {option}`environment.sessionVariables` for
-            this user if {option}`xdg.enable` is `true`.
+            this user if changed.
           '';
         };
         files = mkOption {
@@ -314,11 +312,11 @@ in {
 
   config = {
     environment = {
-      sessionVariables = mkIf cfg.xdg.enable {
-        XDG_CACHE_HOME = cfg.xdg.cache.home;
-        XDG_CONFIG_HOME = cfg.xdg.config.home;
-        XDG_DATA_HOME = cfg.xdg.data.home;
-        XDG_STATE_HOME = cfg.xdg.state.home;
+      sessionVariables = {
+        XDG_CACHE_HOME = mkIf (cfg.xdg.cache.home != "${cfg.directory}/.cache") cfg.xdg.cache.home;
+        XDG_CONFIG_HOME = mkIf (cfg.xdg.config.home != "${cfg.directory}/.config") cfg.xdg.config.home;
+        XDG_DATA_HOME = mkIf (cfg.xdg.data.home != "${cfg.directory}/.local/share") cfg.xdg.data.home;
+        XDG_STATE_HOME = mkIf (cfg.xdg.state.home != "${cfg.directory}/.local/state") cfg.xdg.state.home;
       };
       loadEnv = let
         toEnv = env:

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -191,7 +191,7 @@ in {
 
     xdg = {
       cache = {
-        home = mkOption {
+        directory = mkOption {
           type = path;
           default = "${cfg.directory}/.cache";
           defaultText = "~/.cache";
@@ -205,14 +205,14 @@ in {
         };
         files = mkOption {
           default = {};
-          type = attrsOf (fileType cfg.xdg.cache.home);
+          type = attrsOf (fileType cfg.xdg.cache.directory);
           example = {"foo.txt".source = "Hello World";};
           description = "Cache files to be managed by Hjem";
         };
       };
 
       config = {
-        home = mkOption {
+        directory = mkOption {
           type = path;
           default = "${cfg.directory}/.config";
           defaultText = "~/.config";
@@ -226,14 +226,14 @@ in {
         };
         files = mkOption {
           default = {};
-          type = attrsOf (fileType cfg.xdg.config.home);
+          type = attrsOf (fileType cfg.xdg.config.directory);
           example = {"foo.txt".source = "Hello World";};
           description = "Config files to be managed by Hjem";
         };
       };
 
       data = {
-        home = mkOption {
+        directory = mkOption {
           type = path;
           default = "${cfg.directory}/.local/share";
           defaultText = "~/.local/share";
@@ -247,14 +247,14 @@ in {
         };
         files = mkOption {
           default = {};
-          type = attrsOf (fileType cfg.xdg.data.home);
+          type = attrsOf (fileType cfg.xdg.data.directory);
           example = {"foo.txt".source = "Hello World";};
           description = "data files to be managed by Hjem";
         };
       };
 
       state = {
-        home = mkOption {
+        directory = mkOption {
           type = path;
           default = "${cfg.directory}/.local/state";
           defaultText = "~/.local/share";
@@ -268,7 +268,7 @@ in {
         };
         files = mkOption {
           default = {};
-          type = attrsOf (fileType cfg.xdg.state.home);
+          type = attrsOf (fileType cfg.xdg.state.directory);
           example = {"foo.txt".source = "Hello World";};
           description = "state files to be managed by Hjem";
         };
@@ -313,10 +313,10 @@ in {
   config = {
     environment = {
       sessionVariables = {
-        XDG_CACHE_HOME = mkIf (cfg.xdg.cache.home != "${cfg.directory}/.cache") cfg.xdg.cache.home;
-        XDG_CONFIG_HOME = mkIf (cfg.xdg.config.home != "${cfg.directory}/.config") cfg.xdg.config.home;
-        XDG_DATA_HOME = mkIf (cfg.xdg.data.home != "${cfg.directory}/.local/share") cfg.xdg.data.home;
-        XDG_STATE_HOME = mkIf (cfg.xdg.state.home != "${cfg.directory}/.local/state") cfg.xdg.state.home;
+        XDG_CACHE_HOME = mkIf (cfg.xdg.cache.directory != "${cfg.directory}/.cache") cfg.xdg.cache.directory;
+        XDG_CONFIG_HOME = mkIf (cfg.xdg.config.directory != "${cfg.directory}/.config") cfg.xdg.config.directory;
+        XDG_DATA_HOME = mkIf (cfg.xdg.data.directory != "${cfg.directory}/.local/share") cfg.xdg.data.directory;
+        XDG_STATE_HOME = mkIf (cfg.xdg.state.directory != "${cfg.directory}/.local/state") cfg.xdg.state.directory;
       };
       loadEnv = let
         toEnv = env:

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -4,6 +4,7 @@
 # be avoided here.
 {
   config,
+  options,
   pkgs,
   lib,
   ...
@@ -313,10 +314,10 @@ in {
   config = {
     environment = {
       sessionVariables = {
-        XDG_CACHE_HOME = mkIf (cfg.xdg.cache.directory != "${cfg.directory}/.cache") cfg.xdg.cache.directory;
-        XDG_CONFIG_HOME = mkIf (cfg.xdg.config.directory != "${cfg.directory}/.config") cfg.xdg.config.directory;
-        XDG_DATA_HOME = mkIf (cfg.xdg.data.directory != "${cfg.directory}/.local/share") cfg.xdg.data.directory;
-        XDG_STATE_HOME = mkIf (cfg.xdg.state.directory != "${cfg.directory}/.local/state") cfg.xdg.state.directory;
+        XDG_CACHE_HOME = mkIf (cfg.xdg.cache.directory != options.xdg.cache.directory.default) cfg.xdg.cache.directory;
+        XDG_CONFIG_HOME = mkIf (cfg.xdg.config.directory != options.xdg.config.directory.default) cfg.xdg.config.directory;
+        XDG_DATA_HOME = mkIf (cfg.xdg.data.directory != options.xdg.data.directory.default) cfg.xdg.data.directory;
+        XDG_STATE_HOME = mkIf (cfg.xdg.state.directory != options.xdg.state.directory.default) cfg.xdg.state.directory;
       };
       loadEnv = let
         toEnv = env:

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -192,6 +192,27 @@ in {
     xdg = {
       enable = mkEnableOption "XDG management for this user";
 
+      cache = {
+        home = mkOption {
+          type = path;
+          default = "${cfg.directory}/.cache";
+          defaultText = "~/.cache";
+          description = ''
+            The XDG cache directory for the user, to which files configured in
+            {option}`hjem.users.<name>.xdg.cache.files` will be relative to by default.
+
+            Adds {env}`XDG_CACHE_HOME` to {option}`environment.sessionVariables` for
+            this user if {option}`xdg.enable` is `true`.
+          '';
+        };
+        files = mkOption {
+          default = {};
+          type = attrsOf (fileType cfg.xdg.cache.home);
+          example = {"foo.txt".source = "Hello World";};
+          description = "Cache files to be managed by Hjem";
+        };
+      };
+
       config = {
         home = mkOption {
           type = path;
@@ -252,6 +273,7 @@ in {
   config = {
     environment = {
       sessionVariables = mkIf cfg.xdg.enable {
+        XDG_CACHE_HOME = cfg.xdg.cache.home;
         XDG_CONFIG_HOME = cfg.xdg.config.home;
       };
       loadEnv = let

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -233,6 +233,7 @@ in {
           description = "Config files to be managed by Hjem";
         };
       };
+
       data = {
         home = mkOption {
           type = path;
@@ -251,6 +252,27 @@ in {
           type = attrsOf (fileType cfg.xdg.data.home);
           example = {"foo.txt".source = "Hello World";};
           description = "data files to be managed by Hjem";
+        };
+      };
+
+      state = {
+        home = mkOption {
+          type = path;
+          default = "${cfg.directory}/.local/state";
+          defaultText = "~/.local/share";
+          description = ''
+            The XDG state directory for the user, to which files configured in
+            {option}`hjem.users.<name>.xdg.state.files` will be relative to by default.
+
+            Adds {env}`XDG_STATE_HOME` to {option}`environment.sessionVariables` for
+            this user if {option}`xdg.enable` is `true`.
+          '';
+        };
+        files = mkOption {
+          default = {};
+          type = attrsOf (fileType cfg.xdg.state.home);
+          example = {"foo.txt".source = "Hello World";};
+          description = "state files to be managed by Hjem";
         };
       };
     };
@@ -296,6 +318,7 @@ in {
         XDG_CACHE_HOME = cfg.xdg.cache.home;
         XDG_CONFIG_HOME = cfg.xdg.config.home;
         XDG_DATA_HOME = cfg.xdg.data.home;
+        XDG_STATE_HOME = cfg.xdg.state.home;
       };
       loadEnv = let
         toEnv = env:

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -233,6 +233,26 @@ in {
           description = "Config files to be managed by Hjem";
         };
       };
+      data = {
+        home = mkOption {
+          type = path;
+          default = "${cfg.directory}/.local/share";
+          defaultText = "~/.local/share";
+          description = ''
+            The XDG data directory for the user, to which files configured in
+            {option}`hjem.users.<name>.xdg.data.files` will be relative to by default.
+
+            Adds {env}`XDG_DATA_HOME` to {option}`environment.sessionVariables` for
+            this user if {option}`xdg.enable` is `true`.
+          '';
+        };
+        files = mkOption {
+          default = {};
+          type = attrsOf (fileType cfg.xdg.data.home);
+          example = {"foo.txt".source = "Hello World";};
+          description = "data files to be managed by Hjem";
+        };
+      };
     };
 
     packages = mkOption {
@@ -275,6 +295,7 @@ in {
       sessionVariables = mkIf cfg.xdg.enable {
         XDG_CACHE_HOME = cfg.xdg.cache.home;
         XDG_CONFIG_HOME = cfg.xdg.config.home;
+        XDG_DATA_HOME = cfg.xdg.data.home;
       };
       loadEnv = let
         toEnv = env:

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -194,7 +194,7 @@ in {
         directory = mkOption {
           type = path;
           default = "${cfg.directory}/.cache";
-          defaultText = "~/.cache";
+          defaultText = "$HOME/.cache";
           description = ''
             The XDG cache directory for the user, to which files configured in
             {option}`hjem.users.<name>.xdg.cache.files` will be relative to by default.
@@ -215,7 +215,7 @@ in {
         directory = mkOption {
           type = path;
           default = "${cfg.directory}/.config";
-          defaultText = "~/.config";
+          defaultText = "$HOME/.config";
           description = ''
             The XDG config directory for the user, to which files configured in
             {option}`hjem.users.<name>.xdg.config.files` will be relative to by default.
@@ -236,7 +236,7 @@ in {
         directory = mkOption {
           type = path;
           default = "${cfg.directory}/.local/share";
-          defaultText = "~/.local/share";
+          defaultText = "$HOME/.local/share";
           description = ''
             The XDG data directory for the user, to which files configured in
             {option}`hjem.users.<name>.xdg.data.files` will be relative to by default.
@@ -257,7 +257,7 @@ in {
         directory = mkOption {
           type = path;
           default = "${cfg.directory}/.local/state";
-          defaultText = "~/.local/share";
+          defaultText = "$HOME/.local/share";
           description = ''
             The XDG state directory for the user, to which files configured in
             {option}`hjem.users.<name>.xdg.state.files` will be relative to by default.

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -23,6 +23,7 @@
     // (optionalAttrs user.xdg.enable (
       user.xdg.cache.files
       // user.xdg.config.files
+      // user.xdg.data.files
     ));
 
   linker = getExe cfg.linker;

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -24,6 +24,7 @@
       user.xdg.cache.files
       // user.xdg.config.files
       // user.xdg.data.files
+      // user.xdg.state.files
     ));
 
   linker = getExe cfg.linker;

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -5,7 +5,6 @@
   ...
 }: let
   inherit (lib.attrsets) filterAttrs mapAttrsToList;
-  inherit (lib.lists) optionals;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) literalExpression mkOption;
   inherit (lib.strings) optionalString;
@@ -19,16 +18,13 @@
   enabledUsers = filterAttrs (_: u: u.enable) cfg.users;
   disabledUsers = filterAttrs (_: u: !u.enable) cfg.users;
 
-  userFiles = user:
-    [
-      user.files
-    ]
-    ++ (optionals user.xdg.enable [
-      user.xdg.cache.files
-      user.xdg.config.files
-      user.xdg.data.files
-      user.xdg.state.files
-    ]);
+  userFiles = user: [
+    user.files
+    user.xdg.cache.files
+    user.xdg.config.files
+    user.xdg.data.files
+    user.xdg.state.files
+  ];
 
   linker = getExe cfg.linker;
 

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -20,7 +20,10 @@
 
   userFiles = user:
     user.files
-    // (optionalAttrs user.xdg.enable user.xdg.config.files);
+    // (optionalAttrs user.xdg.enable (
+      user.xdg.cache.files
+      // user.xdg.config.files
+    ));
 
   linker = getExe cfg.linker;
 

--- a/tests/xdg-linker.nix
+++ b/tests/xdg-linker.nix
@@ -1,0 +1,125 @@
+let
+  userHome = "/home/alice";
+in
+  (import ./lib) {
+    name = "hjem-xdg-linker";
+    nodes = {
+      node1 = {
+        self,
+        pkgs,
+        inputs,
+        lib,
+        ...
+      }: let
+        xdg = {clobber}: {
+          enable = true;
+          cache = {
+            home = userHome + "/customCacheHome";
+            files = {
+              "foo" = {
+                text = "Hello world!";
+                inherit clobber;
+              };
+            };
+          };
+          config = {
+            home = userHome + "/customConfigHome";
+            files = {
+              "bar.json" = {
+                generator = lib.generators.toJSON {};
+                value = {bar = true;};
+                inherit clobber;
+              };
+            };
+          };
+          data = {
+            home = userHome + "/customDataHome";
+            files = {
+              "baz.toml" = {
+                generator = (pkgs.formats.toml {}).generate "baz.toml";
+                value = {baz = true;};
+                inherit clobber;
+              };
+            };
+          };
+          state = {
+            home = userHome + "/customStateHome";
+            files = {
+              "foo" = {
+                source = pkgs.writeText "file-bar" "Hello World!";
+                inherit clobber;
+              };
+            };
+          };
+        };
+      in {
+        imports = [self.nixosModules.hjem];
+
+        system.switch.enable = true;
+
+        users.groups.alice = {};
+        users.users.alice = {
+          isNormalUser = true;
+          home = userHome;
+          password = "";
+        };
+
+        hjem = {
+          linker = inputs.smfh.packages.${pkgs.system}.default;
+          users = {
+            alice = {
+              enable = true;
+            };
+          };
+        };
+
+        specialisation = {
+          filesGetsLinked.configuration = {
+            hjem.users.alice = {
+              files.".config/foo".text = "Hello world!";
+              xdg = xdg {clobber = false;};
+            };
+          };
+
+          filesGetsOverwritten.configuration = {
+            hjem.users.alice = {
+              files.".config/foo" = {
+                text = "Hello new world!";
+                clobber = true;
+              };
+              xdg = xdg {clobber = true;};
+            };
+          };
+        };
+      };
+    };
+
+    testScript = {nodes, ...}: let
+      baseSystem = nodes.node1.system.build.toplevel;
+      specialisations = "${baseSystem}/specialisation";
+    in
+      # py
+      ''
+        node1.succeed("loginctl enable-linger alice")
+
+        with subtest("File gets linked"):
+          node1.succeed("${specialisations}/filesGetsLinked/bin/switch-to-configuration test")
+          node1.succeed("test -L ${userHome}/customCacheHome/foo")
+          node1.succeed("test -L ${userHome}/customConfigHome/bar.json")
+          node1.succeed("test -L ${userHome}/customDataHome/baz.toml")
+          node1.succeed("test -L ${userHome}/customStateHome/foo")
+          # Same name as config.home test file to verify proper merging
+          node1.succeed("test -L ${userHome}/.config/foo")
+          node1.succeed("grep \"Hello world!\" ${userHome}/.config/foo")
+
+        with subtest("File gets overwritten when changed"):
+          node1.succeed("${specialisations}/filesGetsLinked/bin/switch-to-configuration test")
+          node1.succeed("${specialisations}/filesGetsOverwritten/bin/switch-to-configuration test")
+          node1.succeed("test -L ${userHome}/customCacheHome/foo")
+          node1.succeed("test -L ${userHome}/customConfigHome/bar.json")
+          node1.succeed("test -L ${userHome}/customDataHome/baz.toml")
+          node1.succeed("test -L ${userHome}/customStateHome/foo")
+          node1.succeed("test -L ${userHome}/.config/foo")
+          node1.succeed("grep \"Hello new world!\" ${userHome}/.config/foo")
+      '';
+  }

--- a/tests/xdg-linker.nix
+++ b/tests/xdg-linker.nix
@@ -18,7 +18,7 @@ in
           altLocation,
         }: {
           cache = {
-            home = mkIf altLocation (userHome + "/customCacheHome");
+            directory = mkIf altLocation (userHome + "/customCacheDirectory");
             files = {
               "foo" = {
                 text = "Hello world!";
@@ -27,7 +27,7 @@ in
             };
           };
           config = {
-            home = mkIf altLocation (userHome + "/customConfigHome");
+            directory = mkIf altLocation (userHome + "/customConfigDirectory");
             files = {
               "bar.json" = {
                 generator = lib.generators.toJSON {};
@@ -37,7 +37,7 @@ in
             };
           };
           data = {
-            home = mkIf altLocation (userHome + "/customDataHome");
+            directory = mkIf altLocation (userHome + "/customDataDirectory");
             files = {
               "baz.toml" = {
                 generator = (pkgs.formats.toml {}).generate "baz.toml";
@@ -47,7 +47,7 @@ in
             };
           };
           state = {
-            home = mkIf altLocation (userHome + "/customStateHome");
+            directory = mkIf altLocation (userHome + "/customStateDirectory");
             files = {
               "foo" = {
                 source = pkgs.writeText "file-bar" "Hello World!";
@@ -129,21 +129,21 @@ in
 
         with subtest("Alternate file locations get linked"):
           node1.succeed("${specialisations}/altFilesGetLinked/bin/switch-to-configuration test")
-          node1.succeed("test -L ${userHome}/customCacheHome/foo")
-          node1.succeed("test -L ${userHome}/customConfigHome/bar.json")
-          node1.succeed("test -L ${userHome}/customDataHome/baz.toml")
-          node1.succeed("test -L ${userHome}/customStateHome/foo")
-          # Same name as config.home test file to verify proper merging
+          node1.succeed("test -L ${userHome}/customCacheDirectory/foo")
+          node1.succeed("test -L ${userHome}/customConfigDirectory/bar.json")
+          node1.succeed("test -L ${userHome}/customDataDirectory/baz.toml")
+          node1.succeed("test -L ${userHome}/customStateDirectory/foo")
+          # Same name as config test file to verify proper merging
           node1.succeed("test -L ${userHome}/.config/foo")
           node1.succeed("grep \"Hello world!\" ${userHome}/.config/foo")
 
         with subtest("Alternate file locations get overwritten when changed"):
           node1.succeed("${specialisations}/altFilesGetLinked/bin/switch-to-configuration test")
           node1.succeed("${specialisations}/altFilesGetOverwritten/bin/switch-to-configuration test")
-          node1.succeed("test -L ${userHome}/customCacheHome/foo")
-          node1.succeed("test -L ${userHome}/customConfigHome/bar.json")
-          node1.succeed("test -L ${userHome}/customDataHome/baz.toml")
-          node1.succeed("test -L ${userHome}/customStateHome/foo")
+          node1.succeed("test -L ${userHome}/customCacheDirectory/foo")
+          node1.succeed("test -L ${userHome}/customConfigDirectory/bar.json")
+          node1.succeed("test -L ${userHome}/customDataDirectory/baz.toml")
+          node1.succeed("test -L ${userHome}/customStateDirectory/foo")
           node1.succeed("test -L ${userHome}/.config/foo")
           node1.succeed("grep \"Hello new world!\" ${userHome}/.config/foo")
       '';

--- a/tests/xdg.nix
+++ b/tests/xdg.nix
@@ -50,6 +50,14 @@ in
                   };
                 };
               };
+              state = {
+                home = userHome + "/customStateHome";
+                files = {
+                  "bar" = {
+                    source = pkgs.writeText "file-bar" "Hello World!";
+                  };
+                };
+              };
             };
           };
         };
@@ -75,6 +83,7 @@ in
       machine.succeed("[ -L ~alice/customCacheHome/foo ]")
       machine.succeed("[ -L ~alice/customConfigHome/bar.json ]")
       machine.succeed("[ -L ~alice/customDataHome/baz.toml ]")
+      machine.succeed("[ -L ~alice/customStateHome/bar ]")
 
       # Test regular files, created by systemd-tmpfiles
       machine.succeed("[ -d ~alice/user_tmpfiles_created ]")

--- a/tests/xdg.nix
+++ b/tests/xdg.nix
@@ -41,6 +41,15 @@ in
                   };
                 };
               };
+              data = {
+                home = userHome + "/customDataHome";
+                files = {
+                  "baz.toml" = {
+                    generator = (pkgs.formats.toml {}).generate "baz.toml";
+                    value = {baz = true;};
+                  };
+                };
+              };
             };
           };
         };
@@ -65,6 +74,7 @@ in
       # Test file created by Hjem
       machine.succeed("[ -L ~alice/customCacheHome/foo ]")
       machine.succeed("[ -L ~alice/customConfigHome/bar.json ]")
+      machine.succeed("[ -L ~alice/customDataHome/baz.toml ]")
 
       # Test regular files, created by systemd-tmpfiles
       machine.succeed("[ -d ~alice/user_tmpfiles_created ]")

--- a/tests/xdg.nix
+++ b/tests/xdg.nix
@@ -22,6 +22,12 @@ in
         hjem.users = {
           alice = {
             enable = true;
+            files = {
+              "bar.json" = {
+                generator = (pkgs.formats.toml {}).generate "baz.toml";
+                value = {baz = true;};
+              };
+            };
             xdg = {
               enable = true;
               cache = {
@@ -79,12 +85,18 @@ in
       machine.succeed("loginctl enable-linger alice")
       machine.wait_until_succeeds("systemctl --user --machine=alice@ is-active systemd-tmpfiles-setup.service")
 
-      # Test file created by Hjem
+
+      # Test XDG files created by Hjem
       machine.succeed("[ -L ~alice/customCacheHome/foo ]")
       machine.succeed("[ -L ~alice/customConfigHome/bar.json ]")
       machine.succeed("[ -L ~alice/customDataHome/baz.toml ]")
+      # Same name as config.home test file to verify proper merging
       machine.succeed("[ -L ~alice/customStateHome/foo ]")
 
+
+      # Basic test file created by Hjem
+      # Same name as cache.home test file to verify proper merging
+      machine.succeed("[ -L ~alice/bar.json ]")
       # Test regular files, created by systemd-tmpfiles
       machine.succeed("[ -d ~alice/user_tmpfiles_created ]")
       machine.succeed("[ -d ~alice/only_alice ]")

--- a/tests/xdg.nix
+++ b/tests/xdg.nix
@@ -30,7 +30,7 @@ in
             };
             xdg = {
               cache = {
-                home = userHome + "/customCacheHome";
+                directory = userHome + "/customCacheDirectory";
                 files = {
                   "foo" = {
                     text = "Hello world!";
@@ -38,7 +38,7 @@ in
                 };
               };
               config = {
-                home = userHome + "/customConfigHome";
+                directory = userHome + "/customConfigDirectory";
                 files = {
                   "bar.json" = {
                     generator = lib.generators.toJSON {};
@@ -47,7 +47,7 @@ in
                 };
               };
               data = {
-                home = userHome + "/customDataHome";
+                directory = userHome + "/customDataDirectory";
                 files = {
                   "baz.toml" = {
                     generator = (pkgs.formats.toml {}).generate "baz.toml";
@@ -56,7 +56,7 @@ in
                 };
               };
               state = {
-                home = userHome + "/customStateHome";
+                directory = userHome + "/customStateDirectory";
                 files = {
                   "foo" = {
                     source = pkgs.writeText "file-bar" "Hello World!";
@@ -86,15 +86,15 @@ in
 
 
       # Test XDG files created by Hjem
-      machine.succeed("[ -L ~alice/customCacheHome/foo ]")
-      machine.succeed("[ -L ~alice/customConfigHome/bar.json ]")
-      machine.succeed("[ -L ~alice/customDataHome/baz.toml ]")
-      # Same name as config.home test file to verify proper merging
-      machine.succeed("[ -L ~alice/customStateHome/foo ]")
+      machine.succeed("[ -L ~alice/customCacheDirectory/foo ]")
+      machine.succeed("[ -L ~alice/customConfigDirectory/bar.json ]")
+      machine.succeed("[ -L ~alice/customDataDirectory/baz.toml ]")
+      # Same name as config test file to verify proper merging
+      machine.succeed("[ -L ~alice/customStateDirectory/foo ]")
 
 
       # Basic test file created by Hjem
-      # Same name as cache.home test file to verify proper merging
+      # Same name as cache test file to verify proper merging
       machine.succeed("[ -L ~alice/bar.json ]")
       # Test regular files, created by systemd-tmpfiles
       machine.succeed("[ -d ~alice/user_tmpfiles_created ]")

--- a/tests/xdg.nix
+++ b/tests/xdg.nix
@@ -53,7 +53,7 @@ in
               state = {
                 home = userHome + "/customStateHome";
                 files = {
-                  "bar" = {
+                  "foo" = {
                     source = pkgs.writeText "file-bar" "Hello World!";
                   };
                 };
@@ -83,7 +83,7 @@ in
       machine.succeed("[ -L ~alice/customCacheHome/foo ]")
       machine.succeed("[ -L ~alice/customConfigHome/bar.json ]")
       machine.succeed("[ -L ~alice/customDataHome/baz.toml ]")
-      machine.succeed("[ -L ~alice/customStateHome/bar ]")
+      machine.succeed("[ -L ~alice/customStateHome/foo ]")
 
       # Test regular files, created by systemd-tmpfiles
       machine.succeed("[ -d ~alice/user_tmpfiles_created ]")

--- a/tests/xdg.nix
+++ b/tests/xdg.nix
@@ -29,7 +29,6 @@ in
               };
             };
             xdg = {
-              enable = true;
               cache = {
                 home = userHome + "/customCacheHome";
                 files = {

--- a/tests/xdg.nix
+++ b/tests/xdg.nix
@@ -24,21 +24,20 @@ in
             enable = true;
             xdg = {
               enable = true;
-              config = {
-                home = userHome + "/customConfigHome";
+              cache = {
+                home = userHome + "/customCacheHome";
                 files = {
                   "foo" = {
                     text = "Hello world!";
                   };
-
+                };
+              };
+              config = {
+                home = userHome + "/customConfigHome";
+                files = {
                   "bar.json" = {
                     generator = lib.generators.toJSON {};
                     value = {bar = true;};
-                  };
-
-                  "baz.toml" = {
-                    generator = (pkgs.formats.toml {}).generate "baz.toml";
-                    value = {baz = true;};
                   };
                 };
               };
@@ -64,9 +63,8 @@ in
       machine.wait_until_succeeds("systemctl --user --machine=alice@ is-active systemd-tmpfiles-setup.service")
 
       # Test file created by Hjem
-      machine.succeed("[ -L ~alice/customConfigHome/foo ]")
+      machine.succeed("[ -L ~alice/customCacheHome/foo ]")
       machine.succeed("[ -L ~alice/customConfigHome/bar.json ]")
-      machine.succeed("[ -L ~alice/customConfigHome/baz.toml ]")
 
       # Test regular files, created by systemd-tmpfiles
       machine.succeed("[ -d ~alice/user_tmpfiles_created ]")


### PR DESCRIPTION
Supersedes #26 

Adds:
- XDG directory management, including adding variables to `sessionVariables`
- XDG files options, matching Home Manager's feature-set
- Tests for the above

Caveats:
- Hjem itself now adds variables to `sessionVariables` itself even though it does not have the capacity to do anything with them. I think this is fine as long as it's disclosed to the user, and Hjem Rum can access and manage those variables.
- Would like to hear thoughts on namespace for the options.
- I could move the xdg tests into `basic` and `linker` respectively, let me know if you would prefer that.