### PR TITLE
modules/xdg: fix documentation error

### DIFF
--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -141,7 +141,7 @@ in {
         directory = mkOption {
           type = path;
           default = "${cfg.directory}/.local/state";
-          defaultText = "$HOME/.local/share";
+          defaultText = "$HOME/.local/state";
           description = ''
             The XDG state directory for the user, to which files configured in
             {option}`hjem.users.<name>.xdg.state.files` will be relative to by default.


### PR DESCRIPTION
XDG state docs said it defaulted to $HOME/.local/share when in reality it was $HOME/.local/state (as it should be).

This fixes the documentation error.