### PR TITLE
modules/systemd: implement recursive linking

### DIFF
--- a/tests/recursive.nix
+++ b/tests/recursive.nix
@@ -1,0 +1,72 @@
+{
+  hjemModule,
+  hjemTest,
+  smfh,
+}: let
+  user = "alice";
+  userHome = "/home/${user}";
+in
+  hjemTest {
+    name = "recursive";
+    nodes = {
+      node1 = {
+        imports = [hjemModule];
+
+        nix.enable = false;
+
+        users.groups.${user} = {};
+        users.users.${user} = {
+          isNormalUser = true;
+          home = userHome;
+          password = "";
+        };
+
+        hjem = {
+          linker = smfh;
+          users = {
+            ${user} = {
+              enable = true;
+            };
+          };
+        };
+
+        specialisation = {
+          creation.configuration = {
+            hjem.users.${user}.systemd.services."test-service" = {
+              serviceConfig = {
+                Type = "oneshot";
+                RemainAfterExit = "yes";
+              };
+              wantedBy = ["default.target"];
+              script = ''
+                echo Test service started
+              '';
+            };
+          };
+
+          deletion.configuration = {};
+        };
+      };
+    };
+
+    testScript = {nodes, ...}: let
+      baseSystem = nodes.node1.system.build.toplevel;
+      specialisations = "${baseSystem}/specialisation";
+    in ''
+      node1.succeed("loginctl enable-linger ${user}")
+
+      with subtest("Service is created"):
+        node1.succeed("${specialisations}/creation/bin/switch-to-configuration test")
+        node1.succeed("test -L ${userHome}/.config/systemd/user/test-service.service")
+        node1.succeed("test -L ${userHome}/.config/systemd/user/default.target.wants/test-service.service")
+
+      with subtest("Service is linked recursively"):
+        node1.succeed("! realpath ${userHome}/.config/systemd/user | grep '/nix/store'")
+        node1.succeed("! realpath ${userHome}/.config/systemd/user/default.target.wants | grep '/nix/store'")
+
+      with subtest("Service is deleted"):
+        node1.succeed("${specialisations}/deletion/bin/switch-to-configuration test")
+        node1.succeed("! test -L ${userHome}/.config/systemd/user/test-service.service")
+        node1.succeed("! test -L ${userHome}/.config/systemd/user/default.target.wants/test-service.service")
+    '';
+  }


### PR DESCRIPTION
Instead of linking a folder into ~/.config/systemd/user link individual files
This avoids overwriting files not created by hjem, and allows users to also create systemd user units imperatively without them getting removed on next rebuild if hjem.clobberByDefault is true.

The current implementation is probably not the greatest approach, as I use builtins.readDir recursively. 
Please let me know if you know of a better approach.
Implementing recursive linking in hjem/smfh would make this trivial. as this is just a specialized version.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

If your pull request aims to fix an open issue or a  bug, please also link the relevant issue below
this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside this
comment, and it will be closed when your pull request is merged.
-->
Fixes #76 

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[CONTRIBUTING]: ../CONTRIBUTING.md
[unit tests]: ../tests

- [x] My changes fit the guidelines found in [CONTRIBUTING] guide
- [x] I have tested, and self-reviewed my code
- [x] The [unit tests] for Hjem pass
- Style and consistency
  - [x] I formatted all relevant code (**nix fmt**)
  - [x] My changes are consistent with the rest of the codebase
  - [x] My commit messages fit the guidelines found in [CONTRIBUTING]
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have included a section in the documentation
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/feel-co/hjem/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
