### PR TITLE
modules/xdg: add mime-apps spec

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -4,10 +4,11 @@
 }: let
   inherit (builtins) elem isList match toJSON;
   inherit (lib.attrsets) filterAttrs;
+  inherit (lib.lists) toList;
   inherit (lib.modules) mkDefault mkDerivedConfig mkIf mkMerge;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
   inherit (lib.strings) concatMapStringsSep hasPrefix;
-  inherit (lib.types) addCheck anything attrsOf bool either enum functionTo int lines listOf nullOr oneOf path str submodule;
+  inherit (lib.types) addCheck anything attrsOf bool coercedTo either enum functionTo int lines listOf nullOr oneOf path str submodule;
 in rec {
   addCheckForTypes = {
     baseType,
@@ -31,6 +32,8 @@ in rec {
   # inlined from https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/config/shells-environment.nix
   # using osOptions precludes using hjem (or this type) standalone
   envVarType = attrsOf (nullOr (oneOf [(listOf (oneOf [int str path])) int str path]));
+
+  listOrSingletonOf = type: coercedTo (either (listOf type) type) toList (listOf type);
 
   fileToJson = f:
     filterAttrs (_: v: v != null) {

--- a/tests/xdg.nix
+++ b/tests/xdg.nix
@@ -64,6 +64,12 @@ in
                   };
                 };
               };
+
+              mime-apps = {
+                added-associations."text/html" = ["firefox.desktop" "zen.desktop"];
+                removed-associations."text/xml" = ["thunderbird.desktop"];
+                default-applications."text/html" = "firefox.desktop";
+              };
             };
           };
         };
@@ -86,7 +92,7 @@ in
       machine.wait_until_succeeds("systemctl --user --machine=alice@ is-active systemd-tmpfiles-setup.service")
 
       # Test XDG files created by Hjem
-      with subtest("XDG files created by Hjem"):
+      with subtest("XDG basedir spec files created by Hjem"):
         machine.succeed("[ -L ~alice/customCacheDirectory/foo ]")
         machine.succeed("grep \"Hello world!\" ~alice/customCacheDirectory/foo")
         machine.succeed("[ -L ~alice/customConfigDirectory/bar.json ]")
@@ -96,6 +102,10 @@ in
         # Same name as config test file to verify proper merging
         machine.succeed("[ -L ~alice/customStateDirectory/foo ]")
         machine.succeed("grep \"Hello fourth world!\" ~alice/customStateDirectory/foo")
+
+      with subtest("XDG mime-apps spec file created by Hjem"):
+        machine.succeed("[ -L ~alice/customConfigDirectory/mimeapps.list ]")
+        machine.succeed("grep \"text/xml\" ~alice/customConfigDirectory/mimeapps.list")
 
       with subtest("Basic test file for Hjem"):
         machine.succeed("[ -L ~alice/foo ]") # Same name as cache test file to verify proper merging


### PR DESCRIPTION
[spec](https://specifications.freedesktop.org/mime-apps/latest/)

Allows configuring default apps to launch given mime types.

Please feel free to nit the PR if you find issues, poorly written Nix, or if I need to write better tests.

Notes:
- This only places the `$XDG_CONFIG_HOME/mimeapps.list` and not the desktop specific version of this config (`$XDG_CONFIG_HOME/$desktop-mimeapps.list`). I'm not sure how to go about including this and if it comes within `hjem`'s scope at all.
- This is disjoint from [`shared-mime-info`](https://specifications.freedesktop.org/shared-mime-info/latest/) which is for defining mime info in user directories like `~/.local/share/mime/`

## Sanity Checking

[CONTRIBUTING]: ../CONTRIBUTING.md
[unit tests]: ../tests

- [x] My changes fit the guidelines found in [CONTRIBUTING] guide
- [x] I have tested, and self-reviewed my code
- [x] The [unit tests] for Hjem pass (`nix flake check`/`nix-build -A checks`)
- Style and consistency
  - [x] I formatted all relevant code (`nix fmt`/`nix run -f . formatter`)
  - [x] My changes are consistent with the rest of the codebase
  - [x] My commit messages fit the guidelines found in [CONTRIBUTING]
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have included a section in the documentation
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

I've tested this in my config and it works fine. Usage:
```nix
hjem.users.primary.xdg.mime-apps.default-applications = {
  "text/html" = [ "firefox.desktop" "helix.desktop" ];
  "x-scheme-handler/http" = "firefox.desktop";
  "x-scheme-handler/https" = "firefox.desktop";
};
```

Resulting in `~/.config/mimeapps.list`:
```
[Default Applications]
text/html=firefox.desktop;helix.desktop
x-scheme-handler/http=firefox.desktop
x-scheme-handler/https=firefox.desktop
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/feel-co/hjem/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
