### PR TITLE
darwin: use watchpaths, remove activationscript

### DIFF
--- a/modules/nix-darwin/base.nix
+++ b/modules/nix-darwin/base.nix
@@ -143,6 +143,8 @@ in {
           });
           Label = "org.hjem.activate";
           RunAtLoad = true;
+          ThrottleInterval = 5;
+          WatchPaths = [ "/nix/var/nix/profiles" ];
           StandardOutPath = "/var/tmp/hjem-activate.out";
           StandardErrorPath = "/var/tmp/hjem-activate.err";
         };
@@ -197,33 +199,12 @@ in {
           });
           Label = "org.nix.link-nix-apps";
           RunAtLoad = true;
+          ThrottleInterval = 5;
+          WatchPaths = [ "/nix/var/nix/profiles" ];
           StandardOutPath = "/var/tmp/link-nix-apps.out";
           StandardErrorPath = "/var/tmp/link-nix-apps.err";
         };
       };
-    };
-
-    system.activationScripts = {
-      hjem-activate-kick.text = mkAfter (
-        concatMapAttrsStringSep "\n"
-        (u: _: ''
-          if uid="$(${getExe' pkgs.coreutils-full "id"} -u ${u} 2>/dev/null)"; then
-            /bin/launchctl kickstart -k "gui/''${uid}/${config.launchd.user.agents.hjem-activate.serviceConfig.Label}" 2>/dev/null || true
-          fi
-        '')
-        enabledUsers
-      );
-
-      # Kick the user agent for every configured user at activation.
-      applications.text = mkAfter (
-        concatMapAttrsStringSep "\n"
-        (u: _: ''
-          if uid="$(${getExe' pkgs.coreutils-full "id"} -u ${u} 2>/dev/null)"; then
-            /bin/launchctl kickstart -k "gui/''${uid}/${config.launchd.user.agents.link-nix-apps.serviceConfig.Label}" 2>/dev/null || true
-          fi
-        '')
-        enabledUsers
-      );
     };
   };
 }


### PR DESCRIPTION
system.activationScripts usage has been discouraged in the project, but the darwin module currently relies on it to kickstart launchd user agents after darwin-rebuild switch.

This can be replaced with a launchd-native approach by using WatchPaths = [ "/nix/var/nix/profiles" ]; in launchd.user.agents. This _seems_ to reliably trigger agents on system generation changes and removes the need for activation-time launchctl kickstart.

[CONTRIBUTING]: ../CONTRIBUTING.md
[unit tests]: ../tests

- [ ] My changes fit the guidelines found in [CONTRIBUTING] guide
- [X] I have tested, and self-reviewed my code
- [ ] The [unit tests] for Hjem pass (`nix flake check`/`nix-build -A checks`)
- Style and consistency
  - [ ] I formatted all relevant code (`nix fmt`/`nix run -f . formatter`)
  - [ ] My changes are consistent with the rest of the codebase
  - [X] My commit messages fit the guidelines found in [CONTRIBUTING]
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have included a section in the documentation
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [X] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/feel-co/hjem/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
