### PR TITLE
nixos: handle Systemd unit reload and restart triggers

### DIFF
--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -49,6 +49,12 @@ jobs:
           - os: ubuntu-22.04-arm
             system: "aarch64-linux"
             test: no-users-linker
+          - os: ubuntu-latest
+            system: "x86_64-linux"
+            test: systemd-reload
+          - os: ubuntu-22.04-arm
+            system: "aarch64-linux"
+            test: systemd-reload
 
 
     runs-on: ${{ matrix.os }}

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -216,8 +216,11 @@ in {
             script = ''
               ${checkEnabledUsers}
 
+              # XXX: This assumes that the XDG runtime directory is /run/user/<uid> which is correct
+              # *most of the time* but we cannot guarantee it. In the future we should try to infer
+              # and respect the existing runtime directory.
               uid=$(id -u)
-              XDG_RUNTIME_DIR="/run/user/$uid" # XXX:we might want to respect existing runtime dir(?)
+              XDG_RUNTIME_DIR="/run/user/$uid"
               export XDG_RUNTIME_DIR
 
               systemd_status=$(systemctl --user is-system-running 2>&1 || true)
@@ -257,14 +260,19 @@ in {
 
                 # Only act on services that existed before; no auto-start for new ones.
                 [ -f "$old_file" ] || continue
-                # Skip services whose unit file is unchanged.
-                cmp --quiet "$old_file" "$new_file" && continue
 
-                if grep -q "^X-Restart-Triggers=" "$new_file"; then
+                # Extract trigger values from old and new unit files (empty string if not present)
+                old_restart=$(grep "^X-Restart-Triggers=" "$old_file" 2>/dev/null | cut -d= -f2- || true)
+                new_restart=$(grep "^X-Restart-Triggers=" "$new_file" 2>/dev/null | cut -d= -f2- || true)
+                old_reload=$(grep "^X-Reload-Triggers=" "$old_file" 2>/dev/null | cut -d= -f2- || true)
+                new_reload=$(grep "^X-Reload-Triggers=" "$new_file" 2>/dev/null | cut -d= -f2- || true)
+
+                # Only restart/reload if the trigger values actually changed
+                if [ -n "$new_restart" ] && [ "$old_restart" != "$new_restart" ]; then
                   echo "Restarting $unit_name for $1 (restart trigger changed)"
                   systemctl --user try-restart "$unit_name" \
                     || echo "Warning: try-restart of $unit_name failed"
-                elif grep -q "^X-Reload-Triggers=" "$new_file"; then
+                elif [ -n "$new_reload" ] && [ "$old_reload" != "$new_reload" ]; then
                   echo "Reloading $unit_name for $1 (reload trigger changed)"
                   systemctl --user reload-or-try-restart "$unit_name" \
                     || echo "Warning: reload-or-try-restart of $unit_name failed"

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -253,7 +253,7 @@ in {
                 exit 0
               fi
 
-              for new_file in "$new_units"/*.service; do
+              for new_file in "$new_units"/*.service "$new_units"/*.timer "$new_units"/*.socket; do
                 [ -f "$new_file" ] || continue
                 unit_name=$(basename "$new_file")
                 old_file="$old_units/$unit_name"

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -144,6 +144,7 @@ in {
         requires = let
           requiredUserServices = name: [
             "hjem-activate@${name}.service"
+            "hjem-reload@${name}.service"
             "hjem-copy@${name}.service"
           ];
         in
@@ -201,11 +202,82 @@ in {
             '';
           };
 
+          "hjem-reload@" = {
+            description = "Reload systemd user units for %i after Hjem file activation";
+            enableStrictShellChecks = true;
+            serviceConfig = {
+              User = "%i";
+              Type = "oneshot";
+            };
+            requires = ["hjem-activate@%i.service"];
+            after = ["hjem-activate@%i.service"];
+            path = [pkgs.jq pkgs.gnugrep];
+            scriptArgs = "%i";
+            script = ''
+              ${checkEnabledUsers}
+
+              uid=$(id -u)
+              XDG_RUNTIME_DIR="/run/user/$uid" # XXX:we might want to respect existing runtime dir(?)
+              export XDG_RUNTIME_DIR
+
+              systemd_status=$(systemctl --user is-system-running 2>&1 || true)
+              if [ "$systemd_status" != "running" ] && [ "$systemd_status" != "degraded" ]; then
+                echo "User systemd for $1 is not running (status: $systemd_status). Skipping."
+                exit 0
+              fi
+
+              new_manifest="${newManifests}/manifest-$1.json"
+              old_manifest="${oldManifests}/manifest-$1.json"
+
+              systemctl --user daemon-reload
+
+              if [ ! -f "$old_manifest" ]; then
+                echo "No previous manifest for $1; skipping trigger-based restarts."
+                exit 0
+              fi
+
+              # head -1: there is exactly one systemd/user entry per user; guard
+              # against pathological manifests with duplicate matches.
+              old_units=$(jq -re \
+                '.files[] | select((.type == "symlink") and (.target | endswith("/systemd/user"))) | .source' \
+                "$old_manifest" 2>/dev/null | head -1 || true)
+              new_units=$(jq -re \
+                '.files[] | select((.type == "symlink") and (.target | endswith("/systemd/user"))) | .source' \
+                "$new_manifest" 2>/dev/null | head -1 || true)
+
+              if [ -z "$old_units" ] || [ -z "$new_units" ]; then
+                echo "No systemd user unit directory in manifest for $1; skipping."
+                exit 0
+              fi
+
+              for new_file in "$new_units"/*.service; do
+                [ -f "$new_file" ] || continue
+                unit_name=$(basename "$new_file")
+                old_file="$old_units/$unit_name"
+
+                # Only act on services that existed before; no auto-start for new ones.
+                [ -f "$old_file" ] || continue
+                # Skip services whose unit file is unchanged.
+                cmp --quiet "$old_file" "$new_file" && continue
+
+                if grep -q "^X-Restart-Triggers=" "$new_file"; then
+                  echo "Restarting $unit_name for $1 (restart trigger changed)"
+                  systemctl --user try-restart "$unit_name" \
+                    || echo "Warning: try-restart of $unit_name failed"
+                elif grep -q "^X-Reload-Triggers=" "$new_file"; then
+                  echo "Reloading $unit_name for $1 (reload trigger changed)"
+                  systemctl --user reload-or-try-restart "$unit_name" \
+                    || echo "Warning: reload-or-try-restart of $unit_name failed"
+                fi
+              done
+            '';
+          };
+
           "hjem-copy@" = {
             description = "Copy the manifest into Hjem's state directory for %i";
             enableStrictShellChecks = true;
             serviceConfig.Type = "oneshot";
-            after = ["hjem-activate@%i.service"];
+            after = ["hjem-reload@%i.service"];
             scriptArgs = "%i";
             /*
             TODO: remove the if condition in a while, this is in place because the first iteration of the

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -211,7 +211,7 @@ in {
             };
             requires = ["hjem-activate@%i.service"];
             after = ["hjem-activate@%i.service"];
-            path = [pkgs.jq pkgs.gnugrep];
+            path = [config.systemd.package pkgs.coreutils-full pkgs.jq pkgs.gnugrep];
             scriptArgs = "%i";
             script = ''
               ${checkEnabledUsers}

--- a/tests/systemd-reload.nix
+++ b/tests/systemd-reload.nix
@@ -16,7 +16,7 @@
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-      ExecStart = "${getExe' pkgs.coreutils "true"}";
+      ExecStart = getExe' pkgs.coreutils "true";
     };
     restartTriggers = [triggerSource];
   };
@@ -29,7 +29,7 @@
     serviceConfig = {
       Type = "simple";
       ExecStart = "${getExe' pkgs.coreutils "sleep"} infinity";
-      ExecReload = "${getExe' pkgs.coreutils "true"}";
+      ExecReload = getExe' pkgs.coreutils "true";
     };
     reloadTriggers = [triggerSource];
   };
@@ -49,7 +49,7 @@
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-      ExecStart = "${getExe' pkgs.coreutils "true"}";
+      ExecStart = getExe' pkgs.coreutils "true";
     };
   };
 
@@ -176,7 +176,7 @@ in
                     RemainAfterExit = true; # FIXME: does ihe test work without this?
 
                     # Use a different binary to change the store path
-                    ExecStart = "${getExe' pkgs.busybox "true"}";
+                    ExecStart = getExe' pkgs.busybox "true";
                   };
                   restartTriggers = [cfg.files.".config/restart-test.conf".source];
                 };
@@ -186,7 +186,7 @@ in
                   serviceConfig = {
                     Type = "simple";
                     ExecStart = "${pkgs.coreutils}/bin/sleep 1000";
-                    ExecReload = "${getExe' pkgs.busybox "true"}";
+                    ExecReload = getExe' pkgs.busybox "true";
                   };
 
                   reloadTriggers = [cfg.files.".config/reload-test.conf".source];

--- a/tests/systemd-reload.nix
+++ b/tests/systemd-reload.nix
@@ -1,0 +1,135 @@
+{
+  hjemModule,
+  hjemTest,
+  smfh,
+  pkgs,
+}: let
+  user = "alice";
+  userHome = "/home/${user}";
+
+  # A oneshot service that stays "active" via RemainAfterExit. Restarting it
+  # produces a new ActiveEnterTimestamp, making restarts unambiguously detectable.
+  restartSvc = name: triggerSource: {
+    description = "Hjem restartTriggers test – ${name}";
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "${pkgs.coreutils}/bin/true";
+    };
+    restartTriggers = [triggerSource];
+  };
+
+  # A long-running service with ExecReload. Reloading it keeps the same MainPID;
+  # only a full restart would change it. This lets us distinguish reload from
+  # restart with certainty.
+  reloadSvc = name: triggerSource: {
+    description = "Hjem reloadTriggers test – ${name}";
+    serviceConfig = {
+      Type = "simple";
+      ExecStart = "${pkgs.coreutils}/bin/sleep infinity";
+      ExecReload = "${pkgs.coreutils}/bin/true";
+    };
+    reloadTriggers = [triggerSource];
+  };
+in
+  hjemTest {
+    name = "hjem-systemd-reload";
+    nodes.node1 = {
+      imports = [hjemModule];
+
+      nix.enable = false;
+
+      users.groups.${user} = {};
+      users.users.${user} = {
+        isNormalUser = true;
+        home = userHome;
+        password = "";
+      };
+
+      hjem = {
+        linker = smfh;
+        users.${user}.enable = true;
+      };
+
+      specialisation = {
+        v1.configuration = {config, ...}: {
+          hjem.users.${user} = {
+            files.".config/restart-test.conf".text = "version=1";
+            files.".config/reload-test.conf".text = "version=1";
+            systemd.services = {
+              restart-test =
+                restartSvc "v1"
+                config.hjem.users.${user}.files.".config/restart-test.conf".source;
+              reload-test =
+                reloadSvc "v1"
+                config.hjem.users.${user}.files.".config/reload-test.conf".source;
+            };
+          };
+        };
+
+        v2.configuration = {config, ...}: {
+          hjem.users.${user} = {
+            files.".config/restart-test.conf".text = "version=2";
+            files.".config/reload-test.conf".text = "version=2";
+            systemd.services = {
+              restart-test =
+                restartSvc "v2"
+                config.hjem.users.${user}.files.".config/restart-test.conf".source;
+              reload-test =
+                reloadSvc "v2"
+                config.hjem.users.${user}.files.".config/reload-test.conf".source;
+            };
+          };
+        };
+      };
+    };
+
+    testScript = {nodes, ...}: let
+      baseSystem = nodes.node1.system.build.toplevel;
+      specialisations = "${baseSystem}/specialisation";
+    in ''
+      node1.succeed("loginctl enable-linger ${user}")
+      uid = node1.succeed("id -u ${user}").strip()
+      xdg = f"/run/user/{uid}"
+      node1.wait_for_unit(f"user@{uid}.service")
+
+      def alice(cmd):
+          return node1.succeed(f"su ${user} -c 'XDG_RUNTIME_DIR={xdg} {cmd}'")
+
+      def alice_show(unit, prop):
+          return alice(f"systemctl --user show {unit} --property={prop} --value").strip()
+
+      with subtest("Deploy v1 and start both services"):
+          node1.succeed("${specialisations}/v1/bin/switch-to-configuration test")
+          alice("systemctl --user start restart-test.service")
+          alice("systemctl --user start reload-test.service")
+          alice("systemctl --user is-active restart-test.service")
+          alice("systemctl --user is-active reload-test.service")
+
+          ts_before  = alice_show("restart-test.service", "ActiveEnterTimestamp")
+          pid_before = alice_show("reload-test.service",  "MainPID")
+
+          assert ts_before  != "", "restart-test has no ActiveEnterTimestamp; service did not start"
+          assert pid_before != "0", "reload-test MainPID is 0; service did not start"
+
+      with subtest("restartTriggers: service is restarted on config change"):
+          node1.succeed("${specialisations}/v2/bin/switch-to-configuration test")
+          alice("systemctl --user is-active restart-test.service")
+
+          ts_after = alice_show("restart-test.service", "ActiveEnterTimestamp")
+          assert ts_before != ts_after, (
+              f"restart-test was NOT restarted: timestamps unchanged ({ts_before})"
+          )
+
+      with subtest("reloadTriggers: service is reloaded (same PID) on config change"):
+          # switch-to-configuration was already called above for v2; both triggers
+          # fire in the same activation.
+          alice("systemctl --user is-active reload-test.service")
+
+          pid_after = alice_show("reload-test.service", "MainPID")
+          assert pid_before == pid_after, (
+              f"reload-test was RESTARTED instead of reloaded: PID changed {pid_before} -> {pid_after}"
+          )
+          assert pid_after != "0", "reload-test MainPID is 0 after reload; service died"
+    '';
+  }

--- a/tests/systemd-reload.nix
+++ b/tests/systemd-reload.nix
@@ -31,6 +31,42 @@
     };
     reloadTriggers = [triggerSource];
   };
+
+  # Timer with restartTriggers. ActiveEnterTimestamp changes on restart, which
+  # makes restarts unambiguously detectable.
+  restartTimer = name: triggerSource: {
+    description = "Hjem restartTriggers test timer – ${name}";
+    timerConfig.OnCalendar = "weekly";
+    restartTriggers = [triggerSource];
+  };
+
+  # Companion service required by restartTimer so that systemd accepts the timer.
+  # The timer refuses to start if its corresponding .service unit is not loaded.
+  timerCompanion = {
+    description = "Hjem restartTriggers test timer companion";
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "${pkgs.coreutils}/bin/true";
+    };
+  };
+
+  # A socket with restartTriggers. ActiveEnterTimestamp changes on restart.
+  restartSocket = name: triggerSource: {
+    description = "Hjem restartTriggers test socket – ${name}";
+    socketConfig.ListenStream = "%t/hjem-restart-test.sock";
+    restartTriggers = [triggerSource];
+  };
+
+  # Companion service required by restartSocket so that systemd accepts the socket.
+  # The socket refuses to start if its corresponding .service unit is not loaded.
+  socketCompanion = {
+    description = "Hjem restartTriggers test socket companion";
+    serviceConfig = {
+      Type = "simple";
+      ExecStart = "${pkgs.coreutils}/bin/sleep infinity";
+    };
+  };
 in
   hjemTest {
     name = "hjem-systemd-reload";
@@ -54,64 +90,122 @@ in
       specialisation = {
         v1.configuration = {config, ...}: {
           hjem.users.${user} = {
-            files.".config/restart-test.conf".text = "version=1";
-            files.".config/reload-test.conf".text = "version=1";
-            systemd.services = {
-              restart-test =
-                restartSvc "v1"
-                config.hjem.users.${user}.files.".config/restart-test.conf".source;
-              reload-test =
-                reloadSvc "v1"
-                config.hjem.users.${user}.files.".config/reload-test.conf".source;
+            files = {
+              ".config/restart-test.conf".text = "version=1";
+              ".config/reload-test.conf".text = "version=1";
+              ".config/timer-test.conf".text = "version=1";
+              ".config/socket-test.conf".text = "version=1";
+            };
+
+            systemd = {
+              services = {
+                restart-test =
+                  restartSvc "v1"
+                  config.hjem.users.${user}.files.".config/restart-test.conf".source;
+                reload-test =
+                  reloadSvc "v1"
+                  config.hjem.users.${user}.files.".config/reload-test.conf".source;
+                restart-test-timer = timerCompanion;
+                restart-test-socket = socketCompanion;
+              };
+
+              timers.restart-test-timer =
+                restartTimer "v1"
+                config.hjem.users.${user}.files.".config/timer-test.conf".source;
+
+              sockets.restart-test-socket =
+                restartSocket "v1"
+                config.hjem.users.${user}.files.".config/socket-test.conf".source;
             };
           };
         };
 
         v2.configuration = {config, ...}: {
           hjem.users.${user} = {
-            files.".config/restart-test.conf".text = "version=2";
-            files.".config/reload-test.conf".text = "version=2";
-            systemd.services = {
-              restart-test =
-                restartSvc "v2"
-                config.hjem.users.${user}.files.".config/restart-test.conf".source;
-              reload-test =
-                reloadSvc "v2"
-                config.hjem.users.${user}.files.".config/reload-test.conf".source;
+            files = {
+              ".config/restart-test.conf".text = "version=2";
+              ".config/reload-test.conf".text = "version=2";
+              ".config/timer-test.conf".text = "version=2";
+              ".config/socket-test.conf".text = "version=2";
+            };
+
+            systemd = {
+              services = {
+                restart-test =
+                  restartSvc "v2"
+                  config.hjem.users.${user}.files.".config/restart-test.conf".source;
+                reload-test =
+                  reloadSvc "v2"
+                  config.hjem.users.${user}.files.".config/reload-test.conf".source;
+                restart-test-timer = timerCompanion;
+                restart-test-socket = socketCompanion;
+              };
+
+              timers.restart-test-timer =
+                restartTimer "v2"
+                config.hjem.users.${user}.files.".config/timer-test.conf".source;
+
+              sockets.restart-test-socket =
+                restartSocket "v2"
+                config.hjem.users.${user}.files.".config/socket-test.conf".source;
             };
           };
         };
 
-        # v3 changes the service config (store paths) but keeps trigger content
-        # the same as v2. Services should NOT restart/reload.
+        # v3 changes unit file contents (store paths) but keeps trigger content
+        # the same as v2. No unit should restart/reload.
         v3.configuration = {config, ...}: {
           hjem.users.${user} = {
-            files.".config/restart-test.conf".text = "version=2";
-            files.".config/reload-test.conf".text = "version=2";
-            systemd.services = {
-              restart-test = {
-                description = "Hjem restartTriggers test – v3";
-                serviceConfig = {
-                  Type = "oneshot";
-                  RemainAfterExit = true;
-                  # Use a different binary to change the store path
-                  ExecStart = "${pkgs.bash}/bin/true";
+            files = {
+              ".config/restart-test.conf".text = "version=2";
+              ".config/reload-test.conf".text = "version=2";
+              ".config/timer-test.conf".text = "version=2";
+              ".config/socket-test.conf".text = "version=2";
+            };
+
+            systemd = let
+              cfg = config.hjem.users.${user};
+            in {
+              services = {
+                restart-test = {
+                  description = "Hjem restartTriggers test – v3";
+                  serviceConfig = {
+                    Type = "oneshot";
+                    RemainAfterExit = true; # FIXME: does ihe test work without this?
+
+                    # Use a different binary to change the store path
+                    ExecStart = "${pkgs.bash}/bin/true";
+                  };
+                  restartTriggers = [cfg.files.".config/restart-test.conf".source];
                 };
-                restartTriggers = [
-                  config.hjem.users.${user}.files.".config/restart-test.conf".source
-                ];
+
+                reload-test = {
+                  description = "Hjem reloadTriggers test – v3";
+                  serviceConfig = {
+                    Type = "simple";
+                    ExecStart = "${pkgs.coreutils}/bin/sleep 1000";
+                    ExecReload = "${pkgs.bash}/bin/true";
+                  };
+
+                  reloadTriggers = [cfg.files.".config/reload-test.conf".source];
+                };
+
+                restart-test-timer = timerCompanion;
+                restart-test-socket = socketCompanion;
               };
-              reload-test = {
-                description = "Hjem reloadTriggers test – v3";
-                serviceConfig = {
-                  Type = "simple";
-                  # Use a different sleep duration to change the store path
-                  ExecStart = "${pkgs.coreutils}/bin/sleep 1000";
-                  ExecReload = "${pkgs.bash}/bin/true";
-                };
-                reloadTriggers = [
-                  config.hjem.users.${user}.files.".config/reload-test.conf".source
-                ];
+
+              timers.restart-test-timer = {
+                # Change OnCalendar to produce a different unit file, trigger content is
+                # unchanged.
+                description = "Hjem restartTriggers test timer – v3";
+                timerConfig.OnCalendar = "monthly";
+                restartTriggers = [cfg.files.".config/timer-test.conf".source];
+              };
+
+              sockets.restart-test-socket = {
+                description = "Hjem restartTriggers test socket – v3";
+                socketConfig.ListenStream = "%t/hjem-restart-test.sock";
+                restartTriggers = [cfg.files.".config/socket-test.conf".source];
               };
             };
           };
@@ -134,18 +228,27 @@ in
       def alice_show(unit, prop):
           return alice(f"systemctl --user show {unit} --property={prop} --value").strip()
 
-      with subtest("Deploy v1 and start both services"):
+      with subtest("Deploy v1 and start all units"):
+          # FIXME: yeesh, this got ugly fast
           node1.succeed("${specialisations}/v1/bin/switch-to-configuration test")
           alice("systemctl --user start restart-test.service")
           alice("systemctl --user start reload-test.service")
+          alice("systemctl --user start restart-test-timer.timer")
+          alice("systemctl --user start restart-test-socket.socket")
           alice("systemctl --user is-active restart-test.service")
           alice("systemctl --user is-active reload-test.service")
+          alice("systemctl --user is-active restart-test-timer.timer")
+          alice("systemctl --user is-active restart-test-socket.socket")
 
-          ts_before  = alice_show("restart-test.service", "ActiveEnterTimestamp")
-          pid_before = alice_show("reload-test.service",  "MainPID")
+          ts_before        = alice_show("restart-test.service",        "ActiveEnterTimestamp")
+          pid_before       = alice_show("reload-test.service",         "MainPID")
+          ts_timer_before  = alice_show("restart-test-timer.timer",    "ActiveEnterTimestamp")
+          ts_socket_before = alice_show("restart-test-socket.socket",  "ActiveEnterTimestamp")
 
-          assert ts_before  != "", "restart-test has no ActiveEnterTimestamp; service did not start"
-          assert pid_before != "0", "reload-test MainPID is 0; service did not start"
+          assert ts_before        != "",  "restart-test has no ActiveEnterTimestamp; service did not start"
+          assert pid_before       != "0", "reload-test MainPID is 0; service did not start"
+          assert ts_timer_before  != "",  "restart-test-timer has no ActiveEnterTimestamp; timer did not start"
+          assert ts_socket_before != "",  "restart-test-socket has no ActiveEnterTimestamp; socket did not start"
 
       with subtest("restartTriggers: service is restarted on config change"):
           node1.succeed("${specialisations}/v2/bin/switch-to-configuration test")
@@ -167,18 +270,40 @@ in
           )
           assert pid_after != "0", "reload-test MainPID is 0 after reload; service died"
 
-      with subtest("unchanged triggers: services stay the same when only store paths change"):
+      with subtest("restartTriggers: timer is restarted on config change"):
+          alice("systemctl --user is-active restart-test-timer.timer")
+
+          ts_timer_after = alice_show("restart-test-timer.timer", "ActiveEnterTimestamp")
+          assert ts_timer_before != ts_timer_after, (
+              f"restart-test-timer was NOT restarted: timestamps unchanged ({ts_timer_before})"
+          )
+
+      with subtest("restartTriggers: socket is restarted on config change"):
+          alice("systemctl --user is-active restart-test-socket.socket")
+
+          ts_socket_after = alice_show("restart-test-socket.socket", "ActiveEnterTimestamp")
+          assert ts_socket_before != ts_socket_after, (
+              f"restart-test-socket was NOT restarted: timestamps unchanged ({ts_socket_before})"
+          )
+
+      with subtest("unchanged triggers: no unit restarts when only store paths change"):
           # Record state after v2
-          ts_v2 = alice_show("restart-test.service", "ActiveEnterTimestamp")
-          pid_v2 = alice_show("reload-test.service", "MainPID")
+          ts_v2        = alice_show("restart-test.service",       "ActiveEnterTimestamp")
+          pid_v2       = alice_show("reload-test.service",        "MainPID")
+          ts_timer_v2  = alice_show("restart-test-timer.timer",   "ActiveEnterTimestamp")
+          ts_socket_v2 = alice_show("restart-test-socket.socket", "ActiveEnterTimestamp")
 
           # Switch to v3, where unit files change but trigger content stays the same
           node1.succeed("${specialisations}/v3/bin/switch-to-configuration test")
           alice("systemctl --user is-active restart-test.service")
           alice("systemctl --user is-active reload-test.service")
+          alice("systemctl --user is-active restart-test-timer.timer")
+          alice("systemctl --user is-active restart-test-socket.socket")
 
-          ts_v3 = alice_show("restart-test.service", "ActiveEnterTimestamp")
-          pid_v3 = alice_show("reload-test.service", "MainPID")
+          ts_v3        = alice_show("restart-test.service",       "ActiveEnterTimestamp")
+          pid_v3       = alice_show("reload-test.service",        "MainPID")
+          ts_timer_v3  = alice_show("restart-test-timer.timer",   "ActiveEnterTimestamp")
+          ts_socket_v3 = alice_show("restart-test-socket.socket", "ActiveEnterTimestamp")
 
           # These should be IDENTICAL since trigger content didn't change
           assert ts_v2 == ts_v3, (
@@ -186,6 +311,12 @@ in
           )
           assert pid_v2 == pid_v3, (
               f"reload-test changed when it shouldn't have: PID changed {pid_v2} -> {pid_v3}"
+          )
+          assert ts_timer_v2 == ts_timer_v3, (
+              f"restart-test-timer was restarted when it shouldn't be: timestamp changed {ts_timer_v2} -> {ts_timer_v3}"
+          )
+          assert ts_socket_v2 == ts_socket_v3, (
+              f"restart-test-socket was restarted when it shouldn't be: timestamp changed {ts_socket_v2} -> {ts_socket_v3}"
           )
     '';
   }

--- a/tests/systemd-reload.nix
+++ b/tests/systemd-reload.nix
@@ -3,7 +3,9 @@
   hjemTest,
   smfh,
   pkgs,
+  lib,
 }: let
+  inherit (lib.meta) getExe';
   user = "alice";
   userHome = "/home/${user}";
 
@@ -14,7 +16,7 @@
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-      ExecStart = "${pkgs.coreutils}/bin/true";
+      ExecStart = "${getExe' pkgs.coreutils "true"}";
     };
     restartTriggers = [triggerSource];
   };
@@ -26,8 +28,8 @@
     description = "Hjem reloadTriggers test – ${name}";
     serviceConfig = {
       Type = "simple";
-      ExecStart = "${pkgs.coreutils}/bin/sleep infinity";
-      ExecReload = "${pkgs.coreutils}/bin/true";
+      ExecStart = "${getExe' pkgs.coreutils "sleep"} infinity";
+      ExecReload = "${getExe' pkgs.coreutils "true"}";
     };
     reloadTriggers = [triggerSource];
   };
@@ -47,7 +49,7 @@
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-      ExecStart = "${pkgs.coreutils}/bin/true";
+      ExecStart = "${getExe' pkgs.coreutils "true"}";
     };
   };
 
@@ -64,7 +66,7 @@
     description = "Hjem restartTriggers test socket companion";
     serviceConfig = {
       Type = "simple";
-      ExecStart = "${pkgs.coreutils}/bin/sleep infinity";
+      ExecStart = "${getExe' pkgs.coreutils "sleep"} infinity";
     };
   };
 in
@@ -174,7 +176,7 @@ in
                     RemainAfterExit = true; # FIXME: does ihe test work without this?
 
                     # Use a different binary to change the store path
-                    ExecStart = "${pkgs.bash}/bin/true";
+                    ExecStart = "${getExe' pkgs.busybox "true"}";
                   };
                   restartTriggers = [cfg.files.".config/restart-test.conf".source];
                 };
@@ -184,7 +186,7 @@ in
                   serviceConfig = {
                     Type = "simple";
                     ExecStart = "${pkgs.coreutils}/bin/sleep 1000";
-                    ExecReload = "${pkgs.bash}/bin/true";
+                    ExecReload = "${getExe' pkgs.busybox "true"}";
                   };
 
                   reloadTriggers = [cfg.files.".config/reload-test.conf".source];

--- a/tests/systemd-reload.nix
+++ b/tests/systemd-reload.nix
@@ -81,6 +81,41 @@ in
             };
           };
         };
+
+        # v3 changes the service config (store paths) but keeps trigger content
+        # the same as v2. Services should NOT restart/reload.
+        v3.configuration = {config, ...}: {
+          hjem.users.${user} = {
+            files.".config/restart-test.conf".text = "version=2";
+            files.".config/reload-test.conf".text = "version=2";
+            systemd.services = {
+              restart-test = {
+                description = "Hjem restartTriggers test – v3";
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                  # Use a different binary to change the store path
+                  ExecStart = "${pkgs.bash}/bin/true";
+                };
+                restartTriggers = [
+                  config.hjem.users.${user}.files.".config/restart-test.conf".source
+                ];
+              };
+              reload-test = {
+                description = "Hjem reloadTriggers test – v3";
+                serviceConfig = {
+                  Type = "simple";
+                  # Use a different sleep duration to change the store path
+                  ExecStart = "${pkgs.coreutils}/bin/sleep 1000";
+                  ExecReload = "${pkgs.bash}/bin/true";
+                };
+                reloadTriggers = [
+                  config.hjem.users.${user}.files.".config/reload-test.conf".source
+                ];
+              };
+            };
+          };
+        };
       };
     };
 
@@ -131,5 +166,26 @@ in
               f"reload-test was RESTARTED instead of reloaded: PID changed {pid_before} -> {pid_after}"
           )
           assert pid_after != "0", "reload-test MainPID is 0 after reload; service died"
+
+      with subtest("unchanged triggers: services stay the same when only store paths change"):
+          # Record state after v2
+          ts_v2 = alice_show("restart-test.service", "ActiveEnterTimestamp")
+          pid_v2 = alice_show("reload-test.service", "MainPID")
+
+          # Switch to v3, where unit files change but trigger content stays the same
+          node1.succeed("${specialisations}/v3/bin/switch-to-configuration test")
+          alice("systemctl --user is-active restart-test.service")
+          alice("systemctl --user is-active reload-test.service")
+
+          ts_v3 = alice_show("restart-test.service", "ActiveEnterTimestamp")
+          pid_v3 = alice_show("reload-test.service", "MainPID")
+
+          # These should be IDENTICAL since trigger content didn't change
+          assert ts_v2 == ts_v3, (
+              f"restart-test was restarted when it shouldn't be: timestamp changed {ts_v2} -> {ts_v3}"
+          )
+          assert pid_v2 == pid_v3, (
+              f"reload-test changed when it shouldn't have: PID changed {pid_v2} -> {pid_v3}"
+          )
     '';
   }


### PR DESCRIPTION
This is a port of my personal reload/restart trigger system, detached from the manifest parser that I ended up writing. *Mostly* streamlined, but the logic might not be as robust as we desire. Partially addresses https://github.com/feel-co/hjem/issues/63

tl;dr: Introduces a new mechanism for automatically reloading or restarting systemd user units when their configuration changes. I've added test cases to make sure they actually work right, but there might be edge cases that I'm not actually seeing here.