### PR TITLE
ci: lint with zizmor; harden permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,12 +13,16 @@ jobs:
   check-formatting:
     name: "check nix formatting"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@11bd0112011b244d6f43aece5ff8411b7815e01b
+        with:
+          persist-credentials: false
 
       - name: "Install Nix"
-        uses: cachix/install-nix-action@v31.10.0
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd
 
       - name: "Evaluate formatting checks"
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,23 +15,21 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
-  pages: write
-  id-token: write
-
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
+  contents: read
+  pages: read
 
 jobs:
   check_date:
     runs-on: ubuntu-latest
     name: Check latest commit
+    permissions:
+      contents: read
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Print latest_commit
         run: "echo Latest commit is: ${{ github.sha }}"
 
@@ -44,10 +42,15 @@ jobs:
   publish:
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    permissions:
+      contents: write
+      pages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31.10.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
@@ -63,7 +66,7 @@ jobs:
           cp -r result/share/doc public
 
       - name: Deploy built documentation
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/.github/workflows/update-inputs.yml
+++ b/.github/workflows/update-inputs.yml
@@ -23,12 +23,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31.10.0
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
@@ -93,7 +94,7 @@ jobs:
 
       - name: Create or update pull request
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8.1.0
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
         with:
           branch: ${{ env.UPDATE_BRANCH }}
           title: "ci: update Nix dependencies"

--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   vm-tests:
     if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -54,7 +56,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v31.10.0
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
@@ -62,7 +64,9 @@ jobs:
             allow-import-from-derivation = false
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Build packages
         run: nix build -L .#checks.${{ matrix.system }}.${{ matrix.test }}


### PR DESCRIPTION
Just ran `nix-shell -p zizmor --run "zizmor .github/workflows"` in the root directory, and fixed the default set of lints. There are a few [other rules](https://docs.zizmor.sh/audits/) but I think the default set handles what we need.