### PR TITLE
modules/common/user: refer to users.‹username›.user as the username

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,9 @@
     nixosModules = import ./modules/nixos;
     darwinModules = import ./modules/nix-darwin;
 
-    overlays = [
-      (import smfhPin).overlays.default
-    ];
+    overlays = {
+      smfh = (import smfhPin).overlays.default;
+    };
 
     packages = forAllSystems (system:
       import ./internal/packages.nix rec {

--- a/modules/common/top-level.nix
+++ b/modules/common/top-level.nix
@@ -110,7 +110,7 @@ in {
           ...
         }: {
           inherit assertion;
-          message = "${user} profile: ${message}";
+          message = "${config.user} profile: ${message}";
         })
         config.assertions)
       enabledUsers)
@@ -126,7 +126,7 @@ in {
       (mapAttrsToList (
           user: v:
             map (
-              warning: "${user} profile: ${warning}"
+              warning: "${v.user} profile: ${warning}"
             )
             v.warnings
         )

--- a/modules/nix-darwin/base.nix
+++ b/modules/nix-darwin/base.nix
@@ -6,7 +6,7 @@
   pkgs,
   ...
 }: let
-  inherit (builtins) attrNames attrValues concatLists concatMap filter getAttr head isAttrs toJSON;
+  inherit (builtins) attrValues concatLists concatMap filter getAttr head isAttrs toJSON;
   inherit (hjem-lib) fileToJson;
   inherit (lib.attrsets) filterAttrs;
   inherit (lib.meta) getExe getExe';
@@ -31,8 +31,8 @@
   linker = getExe cfg.linker;
 
   newManifests = let
-    writeManifest = username: let
-      name = "manifest-${username}.json";
+    writeManifest = user: let
+      name = "manifest-${user.user}.json";
     in
       pkgs.writeTextFile {
         inherit name;
@@ -45,7 +45,7 @@
               (filter (x: x.enable))
               (map fileToJson)
             ]
-          ) (userFiles cfg.users.${username});
+          ) (userFiles user);
         };
         checkPhase = ''
           set -e
@@ -59,7 +59,7 @@
     pkgs.symlinkJoin
     {
       name = "hjem-manifests";
-      paths = map writeManifest (attrNames enabledUsers);
+      paths = map writeManifest (attrValues enabledUsers);
     };
 
   hjemSubmodule = submoduleWith {
@@ -107,7 +107,7 @@ in {
   config = {
     # Temporary requirement: choose a primary user, pick the first enabled user.
     # This option will be deprecated in the future.
-    system.primaryUser = mkDefault (head (attrNames enabledUsers));
+    system.primaryUser = mkDefault (head (map (u: u.user) (attrValues enabledUsers)));
 
     # launchd agent to apply/diff the manifest per logged-in user
     # https://github.com/nix-darwin/nix-darwin/issues/871#issuecomment-2340443820

--- a/modules/nix-darwin/base.nix
+++ b/modules/nix-darwin/base.nix
@@ -6,7 +6,7 @@
   pkgs,
   ...
 }: let
-  inherit (builtins) attrNames attrValues concatLists concatMap filter getAttr head isAttrs toJSON;
+  inherit (builtins) attrValues concatLists concatMap filter getAttr head isAttrs toJSON;
   inherit (hjem-lib) fileToJson;
   inherit (lib.attrsets) filterAttrs;
   inherit (lib.meta) getExe getExe';
@@ -31,8 +31,8 @@
   linker = getExe cfg.linker;
 
   newManifests = let
-    writeManifest = username: let
-      name = "manifest-${username}.json";
+    writeManifest = user: let
+      name = "manifest-${user.user}.json";
     in
       pkgs.writeTextFile {
         inherit name;
@@ -45,7 +45,7 @@
               (filter (x: x.enable))
               (map fileToJson)
             ]
-          ) (userFiles cfg.users.${username});
+          ) (userFiles user);
         };
         checkPhase = ''
           set -e
@@ -59,7 +59,7 @@
     pkgs.symlinkJoin
     {
       name = "hjem-manifests";
-      paths = map writeManifest (attrNames enabledUsers);
+      paths = map writeManifest (attrValues enabledUsers);
     };
 
   hjemSubmodule = submoduleWith {

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -35,8 +35,8 @@
   linker = getExe cfg.linker;
 
   newManifests = let
-    writeManifest = username: let
-      name = "manifest-${username}.json";
+    writeManifest = user: let
+      name = "manifest-${user.user}.json";
     in
       pkgs.writeTextFile {
         inherit name;
@@ -49,7 +49,7 @@
               (filter (x: x.enable))
               (map fileToJson)
             ]
-          ) (userFiles cfg.users.${username});
+          ) (userFiles user);
         };
         checkPhase = ''
           set -e
@@ -63,7 +63,7 @@
     pkgs.symlinkJoin
     {
       name = "hjem-manifests";
-      paths = map writeManifest (attrNames enabledUsers);
+      paths = map writeManifest (attrValues enabledUsers);
     };
 
   hjemSubmodule = submoduleWith {
@@ -148,7 +148,7 @@ in {
             "hjem-copy@${name}.service"
           ];
         in
-          concatMap requiredUserServices (attrNames enabledUsers)
+          concatMap requiredUserServices (map (u: u.user) (attrValues enabledUsers))
           ++ ["hjem-cleanup.service"];
       };
 
@@ -156,7 +156,7 @@ in {
         oldManifests = "/var/lib/hjem";
         checkEnabledUsers = ''
           case "$1" in
-            ${concatStringsSep "|" (attrNames enabledUsers)}) ;;
+            ${concatStringsSep "|" (map (u: u.user) (attrValues enabledUsers))}) ;;
             *) echo "User '%i' is not configured for Hjem" >&2; exit 0 ;;
           esac
         '';

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -35,8 +35,8 @@
   linker = getExe cfg.linker;
 
   newManifests = let
-    writeManifest = username: let
-      name = "manifest-${username}.json";
+    writeManifest = user: let
+      name = "manifest-${user.user}.json";
     in
       pkgs.writeTextFile {
         inherit name;
@@ -49,7 +49,7 @@
               (filter (x: x.enable))
               (map fileToJson)
             ]
-          ) (userFiles cfg.users.${username});
+          ) (userFiles user);
         };
         checkPhase = ''
           set -e
@@ -63,7 +63,7 @@
     pkgs.symlinkJoin
     {
       name = "hjem-manifests";
-      paths = map writeManifest (attrNames enabledUsers);
+      paths = map writeManifest (attrValues enabledUsers);
     };
 
   hjemSubmodule = submoduleWith {
@@ -152,7 +152,7 @@ in {
             "hjem-copy@${name}.service"
           ];
         in
-          concatMap requiredUserServices (attrNames enabledUsers)
+          concatMap requiredUserServices (map (u: u.user) (attrValues enabledUsers))
           ++ ["hjem-cleanup.service"];
       };
 
@@ -160,7 +160,7 @@ in {
         oldManifests = "/var/lib/hjem";
         checkEnabledUsers = ''
           case "$1" in
-            ${concatStringsSep "|" (attrNames enabledUsers)}) ;;
+            ${concatStringsSep "|" (map (u: u.user) (attrValues enabledUsers))}) ;;
             *) echo "User '%i' is not configured for Hjem" >&2; exit 0 ;;
           esac
         '';

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -25,9 +25,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "3440d2940b4c4aa1ee0bf5fcc52c57a1d3ef81f7",
-      "url": "https://github.com/feel-co/smfh/archive/3440d2940b4c4aa1ee0bf5fcc52c57a1d3ef81f7.tar.gz",
-      "hash": "sha256-RgszLC/p9uov6aXnPGbFRkPzT5xleX17wBCdoMT1wcA="
+      "revision": "ed2dea049b06dcd44cb93a443432c02c42b4b882",
+      "url": "https://github.com/feel-co/smfh/archive/ed2dea049b06dcd44cb93a443432c02c42b4b882.tar.gz",
+      "hash": "sha256-OKpQnhlzwcXH1aJvu1NKlepXVPALkZx5GoyhJ8aKLKs="
     }
   },
   "version": 7


### PR DESCRIPTION
Hjem assumes that `username` in `hjem.users.‹username›` is the actual username of the user, which is true in most cases, except when `users.users.‹name›.name` is set to a different value.

This causes [`hjem-activate@`](https://github.com/feel-co/hjem/blob/d51b2e524794a61762453be5bf7b4fe259150191/modules/nixos/base.nix#L172) to fail because it tries to determine the user based on `attrNames hjem.users`.
```
Oct 26 02:40:38 piglin systemd[1]: Starting Link files for primary from their manifest...
Oct 26 02:40:38 piglin (e_-start)[31313]: hjem-activate@primary.service: Failed to determine user credentials: No such process
Oct 26 02:40:38 piglin (e_-start)[31313]: hjem-activate@primary.service: Failed at step USER spawning /nix/store/9x329kaihmbj82m74q7mb1ra2vadba39-unit-script-hjem-activate_-start/bin/hjem-activate_-start: No such process
```

This patch adds `hjem.users.‹username›.name` as a configurable option, and uses `users.users.name` as its default (nixos and nix-darwin alike).

Note that I don't know if I've covered all of the places where a change should be made, which won't be obvious from the PR diff. Happy to go back and add changes in such places if so.

## Sanity Checking

[CONTRIBUTING]: ../CONTRIBUTING.md
[unit tests]: ../tests

- [x] My changes fit the guidelines found in [CONTRIBUTING] guide
- [x] I have tested, and self-reviewed my code
- [x] The [unit tests] for Hjem pass (`nix flake check`/`nix-build -A checks`)
- Style and consistency
  - [x] I formatted all relevant code (`nix fmt`/`nix run -f . formatter`)
  - [ ] My changes are consistent with the rest of the codebase
  - [x] My commit messages fit the guidelines found in [CONTRIBUTING]
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have included a section in the documentation
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/feel-co/hjem/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
