### PR TITLE
modules/nixos: track Systemd units separately

### DIFF
--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -239,27 +239,17 @@ in {
                 exit 0
               fi
 
-              # head -1: there is exactly one systemd/user entry per user; guard
-              # against pathological manifests with duplicate matches.
-              old_units=$(jq -re \
-                '.files[] | select((.type == "symlink") and (.target | endswith("/systemd/user"))) | .source' \
-                "$old_manifest" 2>/dev/null | head -1 || true)
-              new_units=$(jq -re \
-                '.files[] | select((.type == "symlink") and (.target | endswith("/systemd/user"))) | .source' \
-                "$new_manifest" 2>/dev/null | head -1 || true)
+              # Compare trigger values for each individually-linked systemd unit file.
+              # Only act on units that existed before; no auto-start for new ones.
+              while IFS=$'\t' read -r unit_name new_file; do
+                old_file=$(jq -re \
+                  --arg name "$unit_name" \
+                  '.files[] | select((.type == "symlink") and (.target | endswith("/systemd/user/" + $name))) | .source' \
+                  "$old_manifest" 2>/dev/null || true)
 
-              if [ -z "$old_units" ] || [ -z "$new_units" ]; then
-                echo "No systemd user unit directory in manifest for $1; skipping."
-                exit 0
-              fi
-
-              for new_file in "$new_units"/*.service "$new_units"/*.timer "$new_units"/*.socket; do
-                [ -f "$new_file" ] || continue
-                unit_name=$(basename "$new_file")
-                old_file="$old_units/$unit_name"
-
-                # Only act on services that existed before; no auto-start for new ones.
-                [ -f "$old_file" ] || continue
+                if [ -z "$old_file" ] || [ ! -f "$old_file" ] || [ ! -f "$new_file" ]; then
+                  continue
+                fi
 
                 # Extract trigger values from old and new unit files (empty string if not present)
                 old_restart=$(grep "^X-Restart-Triggers=" "$old_file" 2>/dev/null | cut -d= -f2- || true)
@@ -277,7 +267,12 @@ in {
                   systemctl --user reload-or-try-restart "$unit_name" \
                     || echo "Warning: reload-or-try-restart of $unit_name failed"
                 fi
-              done
+              done < <(jq -re \
+                '.files[] | select(
+                  (.type == "symlink") and
+                  (.target | test(".+/systemd/user/[^/]+\\.(service|timer|socket)$"))
+                ) | [(.target | split("/") | last), .source] | @tsv' \
+                "$new_manifest" 2>/dev/null || true)
             '';
           };
 

--- a/modules/nixos/systemd.nix
+++ b/modules/nixos/systemd.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  osConfig,
   utils,
   ...
 }: let
@@ -49,14 +48,20 @@ in {
     };
 
   config = mkIf cfg.enable {
-    xdg.config.files."systemd/user".source = utils.systemdUtils.lib.generateUnits {
-      type = "user";
-      inherit (cfg) units;
-      inherit (osConfig.systemd) package;
-      packages = [];
-      upstreamUnits = [];
-      upstreamWants = [];
-    };
+    xdg.config.files = listToAttrs (
+      flatten (
+        mapAttrsToList (name: unit: let
+          src = "${utils.systemdUtils.lib.makeUnit name unit}/${name}";
+          mkEntry = path: nameValuePair path {source = src;};
+        in
+          [mkEntry "systemd/user/${name}"]
+          ++ map (w: mkEntry "systemd/user/${w}.wants/${name}") (unit.wantedBy or [])
+          ++ map (r: mkEntry "systemd/user/${r}.requires/${name}") (unit.requiredBy or [])
+          ++ map (u: mkEntry "systemd/user/${u}.upholds/${name}") (unit.upheldBy or [])
+          ++ map (a: nameValuePair "systemd/user/${a}" {source = src;}) (unit.aliases or []))
+        cfg.units
+      )
+    );
 
     systemd.units = pipe unitTypes [
       (map

--- a/modules/nixos/systemd.nix
+++ b/modules/nixos/systemd.nix
@@ -4,12 +4,14 @@
   utils,
   ...
 }: let
-  inherit (builtins) listToAttrs;
-  inherit (lib.attrsets) mapAttrsToList nameValuePair;
+  inherit (builtins) listToAttrs pathExists readDir;
+  inherit (lib.attrsets) filterAttrs mapAttrs' mapAttrsToList nameValuePair;
   inherit (lib.lists) flatten;
   inherit (lib.modules) mkIf;
   inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.strings) hasSuffix;
   inherit (lib.trivial) pipe;
+  inherit (lib.types) listOf package;
 
   cfg = config.systemd;
   unitTypes = [
@@ -20,6 +22,41 @@
     "target"
     "timer"
   ];
+
+  # Scan one unit directory from a package, returning a flat attrset of
+  # relative path -> absolute store path for every regular file and symlink.
+  # Subdirectories (e.g., drop-in *.d/, *.requires/, *.upholds/) are recursed one
+  # level deep. .wants/ directories are intentionally skipped.
+  # NixOS does the same, and handles them via a separate upstreamWants mechanism.
+  scanUnitDir = dir:
+    lib.optionalAttrs (pathExists dir) (
+      let
+        entries = filterAttrs (_: t: t != "unknown") (readDir dir);
+      in
+        lib.foldl' (
+          acc: name: let
+            type = entries.${name};
+            path = "${dir}/${name}";
+          in
+            if hasSuffix ".wants" name
+            then acc
+            else if type == "regular" || type == "symlink"
+            then acc // {${name} = path;}
+            else if type == "directory"
+            then
+              acc
+              // mapAttrs'
+              (sub: _: nameValuePair "${name}/${sub}" "${path}/${sub}")
+              (filterAttrs (_: t: t == "regular" || t == "symlink") (readDir path))
+            else acc
+        ) {} (lib.attrNames entries)
+    );
+
+  # Collect all unit files exposed by a package, preferring lib/ over etc/
+  # (same precedence as NixOS: etc/ is scanned first, then lib/ may overwrite).
+  packageUnitFiles = pkg:
+    scanUnitDir "${pkg}/etc/systemd/user"
+    // scanUnitDir "${pkg}/lib/systemd/user";
 in {
   options.systemd =
     pipe unitTypes [
@@ -39,29 +76,53 @@ in {
           example = false;
         };
 
+      packages = mkOption {
+        type = listOf package;
+        default = [];
+        description = ''
+          Packages containing systemd user unit files to be linked into
+          {file}`~/.config/systemd/user/`. Unit files are taken from
+          `$pkg/etc/systemd/user/` and `$pkg/lib/systemd/user/`.
+
+          Units declared in {option}`systemd.services` and friends take
+          precedence over package-provided units with the same name.
+        '';
+      };
+
       units = mkOption {
-        default = {};
         type = utils.systemdUtils.types.units;
+        default = {};
         description = "Internal systemd user unit option to handle transformations.";
         internal = true;
       };
     };
 
   config = mkIf cfg.enable {
-    xdg.config.files = listToAttrs (
-      flatten (
-        mapAttrsToList (name: unit: let
-          src = "${utils.systemdUtils.lib.makeUnit name unit}/${name}";
-          mkEntry = path: nameValuePair path {source = src;};
-        in
-          [mkEntry "systemd/user/${name}"]
-          ++ map (w: mkEntry "systemd/user/${w}.wants/${name}") (unit.wantedBy or [])
-          ++ map (r: mkEntry "systemd/user/${r}.requires/${name}") (unit.requiredBy or [])
-          ++ map (u: mkEntry "systemd/user/${u}.upholds/${name}") (unit.upheldBy or [])
-          ++ map (a: nameValuePair "systemd/user/${a}" {source = src;}) (unit.aliases or []))
-        cfg.units
-      )
-    );
+    xdg.config.files =
+      # Package-provided units come first so that user-declared units
+      # (merged in with //) can override them.
+      lib.foldl' (
+        acc: pkg:
+          acc
+          // mapAttrs'
+          (name: path: nameValuePair "systemd/user/${name}" {source = path;})
+          (packageUnitFiles pkg)
+      ) {}
+      cfg.packages
+      // listToAttrs (
+        flatten (
+          mapAttrsToList (name: unit: let
+            src = "${utils.systemdUtils.lib.makeUnit name unit}/${name}";
+            mkEntry = path: nameValuePair path {source = src;};
+          in
+            [(mkEntry "systemd/user/${name}")]
+            ++ map (w: mkEntry "systemd/user/${w}.wants/${name}") (unit.wantedBy or [])
+            ++ map (r: mkEntry "systemd/user/${r}.requires/${name}") (unit.requiredBy or [])
+            ++ map (u: mkEntry "systemd/user/${u}.upholds/${name}") (unit.upheldBy or [])
+            ++ map (a: nameValuePair "systemd/user/${a}" {source = src;}) (unit.aliases or []))
+          cfg.units
+        )
+      );
 
     systemd.units = pipe unitTypes [
       (map


### PR DESCRIPTION
Fixes https://github.com/feel-co/hjem/issues/76 (at least it tries)

Previously Hjem linked `~/.config/systemd/user` as a single directory symlink to the Nix store. Because the entire directory was owned by a store path, it was impossible to add any files to `~/.config/systemd/user` through other tools, such as but not limited to legacy Home Manager. Users who wanted to manage systemd user units through both Hjem and Home Manager could not do so. 

It's rather...odd in terms of implementation, but since NixOS itself *technically* supports this behaviour I think we should as well. It's also not uncommon for people to run Hjem and Home Manager together during a migration period, or want to support imperative units for *whatever* reason.

Change-Id: Ie53afe84a46074e3cedaa4069d3407e16a6a6964