### PR TITLE
pins: bump ndg to 2.7.0

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -11,10 +11,10 @@
       "version_upper_bound": null,
       "release_prefix": null,
       "submodules": false,
-      "version": "v2.6.0",
-      "revision": "a6bd3c1ce2668d096e4fdaaa03ad7f03ba1fbca8",
-      "url": "https://api.github.com/repos/feel-co/ndg/tarball/refs/tags/v2.6.0",
-      "hash": "sha256-hnBZDQWUxJV3KbtvyGW5BKLO/fAwydrxm5WHCWMQTbw="
+      "version": "v2.7.0",
+      "revision": "ea2526307ad6c7462310e418cee8a6a9bc4003f3",
+      "url": "https://api.github.com/repos/feel-co/ndg/tarball/refs/tags/v2.7.0",
+      "hash": "sha256-PAu6tX0PxuPKro4WJWzxfHCUvsmWuJtgI+msmkNA9AI="
     },
     "smfh": {
       "type": "Git",


### PR DESCRIPTION
Quick PR to bump ndg, which has a bunch of bugfixes and new features we don't need per se, but could use if we wanted to.