### PR TITLE
modules: add user `extraDependencies` support

### DIFF
--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -217,6 +217,19 @@ in {
       description = "Packages to install for this user.";
     };
 
+    extraDependencies = mkOption {
+      type = listOf package;
+      default = [];
+      description = ''
+        A list of paths/packages that should be included in the system closure
+        but generally not visible to users.
+
+        On NixOS these paths are forwarded to {option}`system.extraDependencies`.
+        On nix-darwin, which has no equivalent host option, the paths are pinned
+        to the system closure by listing them in `/etc/hjem/extra-dependencies`.
+      '';
+    };
+
     environment = {
       loadEnv = mkOption {
         type = path;

--- a/modules/nix-darwin/base.nix
+++ b/modules/nix-darwin/base.nix
@@ -11,7 +11,7 @@
   inherit (lib.attrsets) filterAttrs;
   inherit (lib.meta) getExe getExe';
   inherit (lib.modules) importApply mkAfter mkDefault;
-  inherit (lib.strings) concatMapAttrsStringSep escapeShellArgs;
+  inherit (lib.strings) concatLines concatMapAttrsStringSep escapeShellArgs;
   inherit (lib.trivial) flip pipe;
   inherit (lib.types) submoduleWith;
 
@@ -105,6 +105,11 @@ in {
   ];
 
   config = {
+    # nix-darwin has no `system.extraDependencies` equivalent. Best we can do is this.
+    environment.etc."hjem/extra-dependencies".text = concatLines (
+      concatMap (u: map (p: "${p}") u.extraDependencies) (attrValues enabledUsers)
+    );
+
     # Temporary requirement: choose a primary user, pick the first enabled user.
     # This option will be deprecated in the future.
     system.primaryUser = mkDefault (head (attrNames enabledUsers));

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -113,6 +113,10 @@ in {
   ];
 
   config = mkMerge [
+    {
+      system.extraDependencies = concatMap (u: u.extraDependencies) (attrValues enabledUsers);
+    }
+
     # Constructed rule string that consists of the type, target, and source
     # of a tmpfile. Files with 'null' sources are filtered before the rule
     # is constructed.


### PR DESCRIPTION
`system.extraDependencies` by itself is useful because it gives you a declarative GC root tied to the system generation without exposing the dependency as user-facing software. Sometimes you want a store path to survive garbage collection because the machine depends on it operationally, but you do not want it in `environment.systemPackages`, `$PATH`, a service unit, or a fake wrapper.

Thus, with Hjem-standalone now on the agenda, I'm implementing an `extraDependencies` equivalent in Hjem. This lets users avoid having to have Hjem and NixOS module contexts in the same file haphazardly. The best practical case for it is machines where rebuilds, rollbacks, or offline operation matter. You can keep source tarballs, firmware, installers, VM images, model files, generated artifacts, or rarely used recovery tools in the closure without lying to the rest of the system about their role.

Change-Id: I94dd2cc7b2d66e4caa4a6cd26e8d26db6a6a6964