### PR TITLE
lib: allow merging source into attribute sets

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -3,8 +3,8 @@
   pkgs,
 }: let
   inherit (builtins) elem isList match toJSON;
-  inherit (lib.attrsets) filterAttrs;
-  inherit (lib.lists) toList;
+  inherit (lib.attrsets) filterAttrs recursiveUpdate;
+  inherit (lib.lists) foldl' toList;
   inherit (lib.modules) mkDefault mkDerivedConfig mkIf mkMerge;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
   inherit (lib.strings) concatMapStringsSep hasPrefix;
@@ -154,7 +154,11 @@ in rec {
         generator = mkOption {
           # functionTo doesn't actually check the return type, so do that ourselves
           type = addCheck (nullOr (functionTo (either options.source.type options.text.type))) (x: let
-            generatedValue = x config.value;
+            checkValue =
+              if config.value != null
+              then config.value
+              else {};
+            generatedValue = x checkValue;
             generatesDrv = options.source.type.check generatedValue;
             generatesStr = options.text.type.check generatedValue;
           in
@@ -166,6 +170,35 @@ in rec {
             Detection is automatic, as we check if the `generator` generates a derivation or a string after applying to `value`.
           '';
           example = literalExpression "lib.generators.toGitINI";
+        };
+
+        parser = mkOption {
+          type = nullOr (functionTo (attrsOf anything));
+          default = null;
+          description = ''
+            Function that parses each path in `sources` into an attribute set.
+            All parsed results are merged in order, then `value` takes
+            precedence over all of them. The final merged set is passed to
+            `generator`.
+
+            The function receives a path and must return an attribute set.
+
+            Requires `generator` to be set. Has no effect without `sources`.
+          '';
+          example = literalExpression "path: builtins.fromJSON (builtins.readFile path)";
+        };
+
+        sources = mkOption {
+          type = listOf path;
+          default = [];
+          description = ''
+            List of existing files to parse and merge as the base configuration.
+            Parsed in order using `parser`; later entries override earlier ones.
+            `value` then takes precedence over all parsed entries.
+
+            Only meaningful when `parser` is also set.
+          '';
+          example = literalExpression "[ ./base.json ./overrides.json ]";
         };
 
         value = mkOption {
@@ -210,8 +243,27 @@ in rec {
       };
 
       config = let
-        generatedValue = config.generator config.value;
+        hasParser = config.parser != null;
         hasGenerator = config.generator != null;
+
+        # Fold all sources into a single base attrset. config.sources is
+        # independent of config.source, so there is no evaluation cycle.
+        parsedBase =
+          if hasParser
+          then foldl' (acc: path: recursiveUpdate acc (config.parser path)) {} config.sources
+          else {};
+
+        effectiveValue =
+          if hasParser
+          then
+            recursiveUpdate parsedBase (
+              if config.value != null
+              then config.value
+              else {}
+            )
+          else config.value;
+
+        generatedValue = config.generator effectiveValue;
         generatesDrv = options.source.type.check generatedValue;
         generatesStr = options.text.type.check generatedValue;
       in

--- a/tests/parser.nix
+++ b/tests/parser.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  writers,
+  hjemModule,
+  hjemTest,
+}: let
+  userHome = "/home/alice";
+
+  baseJson = writers.writeJSON "base.json" {
+    connection.host = "localhost";
+    connection.port = 5432;
+    logging.level = "info";
+  };
+in
+  hjemTest {
+    name = "hjem-parser";
+    nodes = {
+      node1 = {
+        imports = [hjemModule];
+
+        users = {
+          groups.alice = {};
+          users.alice = {
+            isNormalUser = true;
+            home = userHome;
+            password = "";
+          };
+        };
+
+        hjem = {
+          linker = null;
+          users.alice = {
+            enable = true;
+            files.".config/app.json" = {
+              sources = [baseJson];
+              parser = lib.importJSON;
+              generator = lib.generators.toJSON {};
+              value = {
+                connection.port = 9999;
+                logging.level = "debug";
+                extra.key = "added";
+              };
+            };
+          };
+        };
+      };
+    };
+
+    testScript = ''
+      machine.succeed("loginctl enable-linger alice")
+      machine.wait_until_succeeds("systemctl --user --machine=alice@ is-active systemd-tmpfiles-setup.service")
+
+      machine.succeed("[ -L ~alice/.config/app.json ]")
+
+      content = machine.succeed("cat ~alice/.config/app.json")
+      import json
+      data = json.loads(content)
+
+      # value overrides win
+      assert data["connection"]["port"] == 9999, f"expected port 9999, got {data['connection']['port']}"
+      assert data["logging"]["level"] == "debug", f"expected level debug, got {data['logging']['level']}"
+      # base key inherited from sources
+      assert data["connection"]["host"] == "localhost", f"expected host localhost, got {data['connection']['host']}"
+      # new key from value
+      assert data["extra"]["key"] == "added", f"expected extra.key=added, got {data['extra']['key']}"
+    '';
+  }


### PR DESCRIPTION
Fixes #128 

Introduces a new mechanism for merging configuration from multiple source files using a parser. The non-impure way of doing this is merging *parsable* values with generated ones. Reading absolute paths would be impure, so it's not supported

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/feel-co/hjem/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
