### PR TITLE
various: remove `ndg` pin; update flake inputs and get ndg from Nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-qeRNZKcA0igTdRVnBe6hyo49CqxME92s4G8Sr78ARJw=",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "lastModified": 1779508470,
+        "narHash": "sha256-OtXX32ZNu00Co+iVgV3ffkJVgVVcc0Sy56DdfJm+UQM=",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre992384.549bd84d6279/nixexprs.tar.xz?lastModified=1777954456&rev=549bd84d6279f9852cae6225e372cc67fb91a4c1"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre1003640.299164534138/nixexprs.tar.xz?lastModified=1779508470&rev=29916453413845e54a65b8a1cf996842300cd299"
       },
       "original": {
         "type": "tarball",

--- a/internal/packages.nix
+++ b/internal/packages.nix
@@ -1,11 +1,10 @@
 {
   hjemModule,
-  ndg ? (import ((import ../npins).ndg + "/nix") {inherit pkgs;}).packages.default,
   nixpkgs,
   pkgs,
   smfh,
 }: let
-  docs = pkgs.callPackage ../docs/package.nix {inherit hjemModule ndg nixpkgs;};
+  docs = pkgs.callPackage ../docs/package.nix {inherit hjemModule nixpkgs;};
 in {
   # Expose the 'smfh' instance used by Hjem as a package.
   # This allows consuming the exact copy of smfh used by Hjem.

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1,21 +1,5 @@
 {
   "pins": {
-    "ndg": {
-      "type": "GitRelease",
-      "repository": {
-        "type": "GitHub",
-        "owner": "feel-co",
-        "repo": "ndg"
-      },
-      "pre_releases": false,
-      "version_upper_bound": null,
-      "release_prefix": null,
-      "submodules": false,
-      "version": "v2.8.0",
-      "revision": "86f6644411a64d5413711895b7cf6e0e1be465b6",
-      "url": "https://api.github.com/repos/feel-co/ndg/tarball/refs/tags/v2.8.0",
-      "hash": "sha256-YIKEyzh0NFQlD0O92LQQNMoVCDwV8yw1Xz0Iu+4ZC5U="
-    },
     "smfh": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
ndg has finally made it to Nixpkgs, so we can drop the pin now