### PR TITLE
treewide: drop references to smfh package except for some tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ commands:
 | `nix flake check`  | `nix-build -A checks`        |
 | `nix develop`      | `nix-shell -A shell`         |
 | `nix build .#hjem` | `nix-build -A packages.hjem` |
-| `nix build .#smfh` | `nix-build -A packages.smfh` |
 | `nix fmt`          | `nix run -f . formatter`     |
 
 You can also `import` the root of the repo and get all of the same attributes as

--- a/default.nix
+++ b/default.nix
@@ -2,13 +2,12 @@
 {
   pkgs ? import (import ./internal/flake-parse.nix "nixpkgs") {},
   finix ? (import ./npins).finix,
-  smfh ? pkgs.callPackage ((import ./npins).smfh + "/package.nix") {},
 }: rec {
   checks =
-    import ./internal/checks.nix {inherit smfh pkgs;}
+    import ./internal/checks.nix {inherit pkgs;}
     // import ./internal/finix-checks.nix {inherit finix pkgs;};
   packages = import ./internal/packages.nix {
-    inherit pkgs smfh;
+    inherit pkgs;
     hjemModule = nixosModules.default;
     nixpkgs = pkgs.path;
   };

--- a/flake.nix
+++ b/flake.nix
@@ -12,30 +12,22 @@
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
     finix = (import ./npins).finix;
     pkgsFor = system: nixpkgs.legacyPackages.${system};
-    smfhPin = (import ./npins).smfh;
-    smfhFor = pkgs: pkgs.callPackage (smfhPin + "/package.nix") {};
   in {
     nixosModules = import ./modules/nixos;
     darwinModules = import ./modules/nix-darwin;
     finixModules = import ./modules/finix;
-
-    overlays = {
-      smfh = (import smfhPin).overlays.default;
-    };
 
     packages = forAllSystems (system:
       import ./internal/packages.nix rec {
         inherit nixpkgs;
         hjemModule = self.nixosModules.default;
         pkgs = pkgsFor system;
-        smfh = smfhFor pkgs;
       });
 
     checks = forAllSystems (system:
       import ./internal/checks.nix rec {
         inherit self;
         pkgs = pkgsFor system;
-        smfh = smfhFor pkgs;
       }
       // import ./internal/finix-checks.nix {
         inherit self finix;

--- a/internal/checks.nix
+++ b/internal/checks.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   self ? ../.,
-  smfh,
 }: let
   hjemTest =
     # The first argument to this function is the test module itself
@@ -25,11 +24,6 @@
       directory = ../tests/nixos;
     })
     // {
-      # Build the 'smfh' package as a part of Hjem's test suite.
-      # If 'nix flake check' is ran in the CI, this might inflate build times
-      # *a lot*.
-      inherit smfh;
-
       # Formatting checks to run as a part of 'nix flake check' or manually
       # via 'nix build .#checks.<system>.formatting'.
       formatting =

--- a/internal/packages.nix
+++ b/internal/packages.nix
@@ -2,15 +2,10 @@
   hjemModule,
   nixpkgs,
   pkgs,
-  smfh,
 }: let
   docs = pkgs.callPackage ../docs/package.nix {inherit hjemModule nixpkgs;};
 in {
   hjem = pkgs.callPackage ../cli/package.nix {};
-
-  # Expose the 'smfh' instance used by Hjem as a package.
-  # This allows consuming the exact copy of smfh used by Hjem.
-  inherit smfh;
 
   # Hjem documentation. 'docs-html' contains the HTML document created by ndg
   # and docs-json contains a standalone 'options.json' that is also fed to ndg

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -66,7 +66,9 @@ let
         if pkgs == null
         then {
           inherit (builtins) fetchTarball fetchurl;
-          # For some fucking reason, fetchGit has a different signature than the other builtin fetchers …
+          # Frustratingly, due to flakes and `fetchTree`, `fetchGit`
+          # has a different signature than the other builtin
+          # fetchers
           fetchGit = args: (builtins.fetchGit args).outPath;
         }
         else {
@@ -93,7 +95,6 @@ let
             };
         };
 
-      # Dispatch to the correct code path based on the type
       path =
         if spec.type == "Git"
         then mkGitSource fetchers spec
@@ -103,8 +104,8 @@ let
         then mkPyPiSource fetchers spec
         else if spec.type == "Channel"
         then mkChannelSource fetchers spec
-        else if spec.type == "Tarball"
-        then mkTarballSource fetchers spec
+        else if spec.type == "Url" || spec.type == "MutableUrl"
+        then mkUrlSource fetchers spec
         else if spec.type == "Container"
         then mkContainerSource pkgs spec
         else builtins.throw "Unknown source type ${spec.type}";
@@ -186,14 +187,22 @@ let
       sha256 = hash;
     };
 
-  mkTarballSource = {fetchTarball, ...}: {
+  mkUrlSource = {
+    fetchTarball,
+    fetchurl,
+    ...
+  }: {
     url,
-    locked_url ? url,
     hash,
+    unpack,
     ...
   }:
-    fetchTarball {
-      url = locked_url;
+    (
+      if unpack
+      then fetchTarball
+      else fetchurl
+    ) {
+      inherit url;
       sha256 = hash;
     };
 
@@ -201,16 +210,25 @@ let
     image_name,
     image_tag,
     image_digest,
+    hash,
     ...
-  }:
+  } @ args:
     if pkgs == null
     then builtins.throw "container sources require passing in a Nixpkgs value: https://github.com/andir/npins/blob/master/README.md#using-the-nixpkgs-fetchers"
     else
-      pkgs.dockerTools.pullImage {
-        imageName = image_name;
-        imageDigest = image_digest;
-        finalImageTag = image_tag;
-      };
+      pkgs.dockerTools.pullImage (
+        {
+          imageName = image_name;
+          imageDigest = image_digest;
+          finalImageTag = image_tag;
+          hash = hash;
+        }
+        // (
+          if args.arch or null != null
+          then {arch = args.arch;}
+          else {}
+        )
+      );
 in
   mkFunctor (
     {input ? ./sources.json}: let
@@ -219,7 +237,7 @@ in
         then
           # while `readFile` will throw an error anyways if the path doesn't exist,
           # we still need to check beforehand because *our* error can be caught but not the one from the builtin
-          # *piegames sighs*
+          # See: <https://git.lix.systems/lix-project/lix/issues/1098>
           if builtins.pathExists input
           then builtins.fromJSON (builtins.readFile input)
           else throw "Input path ${toString input} does not exist"
@@ -228,7 +246,7 @@ in
         else throw "Unsupported input type ${builtins.typeOf input}, must be a path or an attrset";
       version = data.version;
     in
-      if version == 7
+      if version == 8
       then builtins.mapAttrs (name: spec: mkFunctor (mkSource name spec)) data.pins
       else throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"
   )

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -12,20 +12,7 @@
       "revision": "b890c8b9bdb1fd09a6c6375a713226e33203af40",
       "url": "https://github.com/finix-community/finix/archive/b890c8b9bdb1fd09a6c6375a713226e33203af40.tar.gz",
       "hash": "sha256-h0xpNVoFR07QXXpq4NO8iWmLJ7n9y4fsCCACWH9o2ow="
-    },
-    "smfh": {
-      "type": "Git",
-      "repository": {
-        "type": "GitHub",
-        "owner": "feel-co",
-        "repo": "smfh"
-      },
-      "branch": "main",
-      "submodules": false,
-      "revision": "3fef284b6d973aac3473861ac70a60c4ab56e743",
-      "url": "https://github.com/feel-co/smfh/archive/3fef284b6d973aac3473861ac70a60c4ab56e743.tar.gz",
-      "hash": "sha256-tU8VxIXYgqN1Wt/P1IWTylRtg2ZYRN4hqEkHwL+NJ0Y="
     }
   },
-  "version": 7
+  "version": 8
 }

--- a/tests/nixos/basic.nix
+++ b/tests/nixos/basic.nix
@@ -20,7 +20,6 @@ in
           password = "";
         };
 
-        hjem.linker = null;
         hjem.users = {
           alice = {
             enable = true;

--- a/tests/nixos/linker.nix
+++ b/tests/nixos/linker.nix
@@ -1,7 +1,7 @@
 {
   hjemModule,
   hjemTest,
-  smfh,
+  pkgs,
 }: let
   user = "alice";
   userHome = "/home/${user}";
@@ -9,8 +9,11 @@
 in
   hjemTest {
     name = "hjem-linker";
-    nodes = {
-      node1 = {
+    nodes = let
+      node = {
+        linker,
+        mountHome ? false,
+      }: {
         imports = [hjemModule];
 
         # ensure nixless deployments work
@@ -24,7 +27,7 @@ in
           inherit uid;
         };
 
-        systemd.mounts = [
+        systemd.mounts = pkgs.lib.optionals mountHome [
           {
             what = "tmpfs";
             where = "/home";
@@ -38,7 +41,7 @@ in
         ];
 
         hjem = {
-          linker = smfh;
+          inherit linker;
           users = {
             ${user} = {
               enable = true;
@@ -82,53 +85,51 @@ in
           };
         };
       };
+    in {
+      nullLinker = node {linker = null;};
+      smfhLinker = node {
+        linker = pkgs.smfh;
+        mountHome = true;
+      };
     };
 
     testScript = {nodes, ...}: let
-      baseSystem = nodes.node1.system.build.toplevel;
-      specialisations = "${baseSystem}/specialisation";
+      nullBaseSystem = nodes.nullLinker.system.build.toplevel;
+      smfhBaseSystem = nodes.smfhLinker.system.build.toplevel;
+      smfhSpecialisations = "${smfhBaseSystem}/specialisation";
     in ''
-      node1.succeed("loginctl enable-linger ${user}")
+      with subtest("linker = null"):
+          nullLinker.succeed("loginctl enable-linger ${user}")
+          nullLinker.succeed("${nullBaseSystem}/bin/switch-to-configuration test")
+          nullLinker.wait_until_succeeds("systemctl --user --machine=${user}@ is-active systemd-tmpfiles-setup.service")
+          nullLinker.succeed("grep 'linked after home.mount' ${userHome}/.config/requires-mounts-for")
 
-      with subtest("Hjem activation mounts the user home before linking"):
-        # XXX: I'm not sure if this is the most appropriate test here. Revisit.
-        node1.succeed("${baseSystem}/bin/switch-to-configuration test")
-        node1.succeed("mountpoint -q /home")
-        node1.succeed("grep ' /home ' /proc/self/mountinfo | grep -qw tmpfs")
-        node1.succeed("grep 'linked after home.mount' ${userHome}/.config/requires-mounts-for")
+      with subtest("linker = pkgs.smfh"):
+          smfhLinker.succeed("loginctl enable-linger ${user}")
+          smfhLinker.succeed("${smfhBaseSystem}/bin/switch-to-configuration test")
+          smfhLinker.succeed("mountpoint -q /home")
+          smfhLinker.succeed("grep ' /home ' /proc/self/mountinfo | grep -qw tmpfs")
+          smfhLinker.succeed("grep 'linked after home.mount' ${userHome}/.config/requires-mounts-for")
+          smfhLinker.succeed("systemctl show servicename --property=Result --value | grep -q '^success$'")
+          smfhLinker.succeed("[ -f /var/lib/hjem/manifest-${user}.json ]")
 
-      with subtest("Activation service runs correctly"):
-        node1.succeed("${baseSystem}/bin/switch-to-configuration test")
-        node1.succeed("systemctl show servicename --property=Result --value | grep -q '^success$'")
+          smfhLinker.succeed("${smfhSpecialisations}/fileGetsLinked/bin/switch-to-configuration test")
+          smfhLinker.succeed("test -L ${userHome}/.config/foo")
+          smfhLinker.succeed("grep 'Hello world!' ${userHome}/.config/foo")
 
-      with subtest("Manifest gets created"):
-        node1.succeed("${baseSystem}/bin/switch-to-configuration test")
-        node1.succeed("[ -f /var/lib/hjem/manifest-${user}.json ]")
+          smfhLinker.succeed("${smfhSpecialisations}/fileGetsOverwritten/bin/switch-to-configuration test")
+          smfhLinker.succeed("test -L ${userHome}/.config/foo")
+          smfhLinker.succeed("grep 'Hello new world!' ${userHome}/.config/foo")
 
-      with subtest("File gets linked"):
-        node1.succeed("${specialisations}/fileGetsLinked/bin/switch-to-configuration test")
-        node1.succeed("test -L ${userHome}/.config/foo")
-        node1.succeed("grep \"Hello world!\" ${userHome}/.config/foo")
-
-      with subtest("File gets overwritten when changed"):
-        node1.succeed("${specialisations}/fileGetsLinked/bin/switch-to-configuration test")
-        node1.succeed("${specialisations}/fileGetsOverwritten/bin/switch-to-configuration test")
-        node1.succeed("test -L ${userHome}/.config/foo")
-        node1.succeed("grep \"Hello new world!\" ${userHome}/.config/foo")
-
-      with subtest("Various file type tests"):
-        node1.succeed("touch ${userHome}/{bar,boop}")
-        node1.succeed("test -f ${userHome}/bar")
-        node1.succeed("test -f ${userHome}/boop")
-        node1.succeed("chmod 644 ${userHome}/boop")
-        node1.succeed("chown ${user} ${userHome}/{bar,boop}")
-        node1.succeed("test $(stat -c '%a' ${userHome}/boop) = \"644\"")
-        node1.succeed("${specialisations}/variousFileTypes/bin/switch-to-configuration test")
-        node1.succeed("test -f ${userHome}/foo")
-        node1.succeed("grep \"test content\" ${userHome}/foo")
-        node1.succeed("! test -f ${userHome}/bar")
-        node1.succeed("test -d ${userHome}/baz")
-        node1.succeed("test -f ${userHome}/boop")
-        node1.succeed("test $(stat -c '%a' ${userHome}/boop) = \"703\"")
+          smfhLinker.succeed("touch ${userHome}/{bar,boop}")
+          smfhLinker.succeed("chmod 644 ${userHome}/boop")
+          smfhLinker.succeed("chown ${user} ${userHome}/{bar,boop}")
+          smfhLinker.succeed("${smfhSpecialisations}/variousFileTypes/bin/switch-to-configuration test")
+          smfhLinker.succeed("test -f ${userHome}/foo")
+          smfhLinker.succeed("grep 'test content' ${userHome}/foo")
+          smfhLinker.succeed("! test -f ${userHome}/bar")
+          smfhLinker.succeed("test -d ${userHome}/baz")
+          smfhLinker.succeed("test -f ${userHome}/boop")
+          smfhLinker.succeed("test $(stat -c '%a' ${userHome}/boop) = '703'")
     '';
   }

--- a/tests/nixos/no-users-linker.nix
+++ b/tests/nixos/no-users-linker.nix
@@ -1,7 +1,7 @@
 {
   hjemModule,
   hjemTest,
-  smfh,
+  pkgs,
 }: let
   user = "alice";
   userHome = "/home/${user}";
@@ -23,7 +23,7 @@ in
         };
 
         hjem = {
-          linker = smfh;
+          linker = pkgs.smfh;
           users = {
             ${user} = {
               enable = false;

--- a/tests/nixos/systemd-reload.nix
+++ b/tests/nixos/systemd-reload.nix
@@ -1,7 +1,6 @@
 {
   hjemModule,
   hjemTest,
-  smfh,
   pkgs,
   lib,
 }: let
@@ -84,10 +83,7 @@ in
         password = "";
       };
 
-      hjem = {
-        linker = smfh;
-        users.${user}.enable = true;
-      };
+      hjem.users.${user}.enable = true;
 
       specialisation = {
         v1.configuration = {config, ...}: {

--- a/tests/nixos/xdg-linker.nix
+++ b/tests/nixos/xdg-linker.nix
@@ -3,7 +3,7 @@
   hjemTest,
   lib,
   formats,
-  smfh,
+  pkgs,
   writeText,
 }: let
   userHome = "/home/alice";
@@ -72,7 +72,7 @@ in
         };
 
         hjem = {
-          linker = smfh;
+          linker = pkgs.smfh;
           users = {
             alice = {
               enable = true;


### PR DESCRIPTION
Removes any references to smfh as a pin/package and its direct integration (and tests) from the codebase since we no longer depend on it as a package. There's one test exercising `pkgs.smfh` as the linker rather than the default. Left some smfh-specific tests to try and make sure we don't break anything for people that want to simply use smfh, even though that's not recommended or directly supported.



