### PR TITLE
treewide: get Hjem CLI from `config.cli.package`

### DIFF
--- a/modules/common/top-level.nix
+++ b/modules/common/top-level.nix
@@ -4,7 +4,6 @@
 }: {
   lib,
   pkgs,
-  hjem-package,
   config,
   ...
 }: let
@@ -21,6 +20,13 @@ in {
   inherit _class;
 
   options.hjem = {
+    cli.package = mkOption {
+      type = package;
+      default = pkgs.callPackage ../../cli/package.nix {};
+      defaultText = literalExpression "pkgs.callPackage ../../cli/package.nix { }";
+      description = "The Hjem CLI package to use.";
+    };
+
     clobberByDefault = mkOption {
       type = bool;
       default = false;
@@ -64,8 +70,8 @@ in {
 
     linker = mkOption {
       type = nullOr package;
-      default = hjem-package;
-      defaultText = literalExpression "hjem-package";
+      default = cfg.cli.package;
+      defaultText = literalExpression "config.hjem.cli.package";
       description = ''
         Package to use to link files.
 

--- a/modules/finix/base.nix
+++ b/modules/finix/base.nix
@@ -1,7 +1,6 @@
 {
   config,
   hjem-lib,
-  hjem-package,
   lib,
   options,
   pkgs,
@@ -49,8 +48,8 @@
     user.xdg.state.files
   ];
 
-  hjemCli = getExe hjem-package;
-  hjemPkg = hjem-package;
+  hjemCli = getExe cfg.cli.package;
+  hjemPkg = cfg.cli.package;
   actualLinker =
     if cfg.linker == null
     then hjemPkg

--- a/modules/finix/default.nix
+++ b/modules/finix/default.nix
@@ -11,10 +11,6 @@ rec {
     ...
   }: {
     _module.args.hjem-lib = import ../../lib.nix {inherit lib pkgs;};
-    _module.args.hjem-package =
-      if pkgs ? hjem
-      then pkgs.hjem
-      else pkgs.callPackage ../../cli/package.nix {};
   };
   default = hjem;
 }

--- a/modules/nix-darwin/base.nix
+++ b/modules/nix-darwin/base.nix
@@ -4,7 +4,6 @@
   lib,
   options,
   pkgs,
-  hjem-package,
   ...
 }: let
   inherit (builtins) attrValues concatLists concatMap filter getAttr head isAttrs toJSON;
@@ -29,8 +28,8 @@
     user.xdg.state.files
   ];
 
-  hjemCli = getExe hjem-package;
-  hjemPkg = hjem-package;
+  hjemCli = getExe cfg.cli.package;
+  hjemPkg = cfg.cli.package;
   useExternalLinker = cfg.linker != hjemPkg;
   linkerExe = getExe cfg.linker;
   prefix =

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -11,10 +11,6 @@ rec {
     ...
   }: {
     _module.args.hjem-lib = import ../../lib.nix {inherit lib pkgs;};
-    _module.args.hjem-package =
-      if pkgs ? hjem
-      then pkgs.hjem
-      else pkgs.callPackage ../../cli/package.nix {};
   };
   default = hjem;
 }

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -4,7 +4,6 @@
   lib,
   options,
   pkgs,
-  hjem-package,
   utils,
   ...
 }: let
@@ -33,8 +32,8 @@
     user.xdg.state.files
   ];
 
-  hjemCli = getExe hjem-package;
-  hjemPkg = hjem-package;
+  hjemCli = getExe cfg.cli.package;
+  hjemPkg = cfg.cli.package;
   useExternalLinker = cfg.linker != hjemPkg;
   linkerExe = getExe cfg.linker;
   prefix =

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -11,10 +11,6 @@ rec {
     ...
   }: {
     _module.args.hjem-lib = import ../../lib.nix {inherit lib pkgs;};
-    _module.args.hjem-package =
-      if pkgs ? hjem
-      then pkgs.hjem
-      else pkgs.callPackage ../../cli/package.nix {};
   };
   default = hjem;
 }


### PR DESCRIPTION
I've previously used a very funky (bad) way of passing the Hjem CLI package around, abusing specialArgs and not letting a clean override. This is obviously very bad etc. and users should be able to override the package. This PR adds `cli.package` as an option and uses it in all modules.

Change-Id: I6c557b1ab8f676a035134461c495b3ba6a6a6964
