### PR TITLE
treewide: Add initial support for external IDPs when users.users.<username> is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ may use to manage individual users' homes by leveraging the module system.
 
 > [!NOTE]
 > Each attribute under `hjem.users`, e.g., `hjem.users.alice` or
-> `hjem.users.jane` represent a user managed via `users.users` in NixOS. If a
-> user does not exist, then Hjem will refuse to manage their `$HOME` by
-> filtering non-existent users in file creation.
+> `hjem.users.jane` represents a user managed via `users.users` in NixOS or a user
+> that is able to be resolved at runtime via external identity managment (e.g., kanidm, LDAP, SSSD).
+> If a user does not exist and `hjem.users.<user>.externalIdp` is disabled, Hjem will
+> refuse to manage their `$HOME` by filtering non-existent users in file creation.
 
 ## Module Interface
 

--- a/modules/common/top-level.nix
+++ b/modules/common/top-level.nix
@@ -16,6 +16,8 @@
   cfg = config.hjem;
 
   enabledUsers = filterAttrs (_: u: u.enable) cfg.users;
+
+  osUsers = filterAttrs (_: u: !u.externalIdp) enabledUsers;
 in {
   inherit _class;
 
@@ -106,7 +108,7 @@ in {
   };
 
   config = {
-    users.users = (mapAttrs (_: v: {inherit (v) packages;})) enabledUsers;
+    users.users = (mapAttrs (_: v: {inherit (v) packages;})) osUsers;
 
     assertions =
       concatLists

--- a/modules/common/user.nix
+++ b/modules/common/user.nix
@@ -49,7 +49,29 @@ in {
 
     user = mkOption {
       type = strMatching "[a-zA-Z0-9_.][a-zA-Z0-9_.-]*";
-      description = "The owner of a given home directory.";
+      description = ''
+        The owner of a given home directory. This can be set to either
+        the username or unix UID.
+      '';
+    };
+
+    externalIdp = mkOption {
+      type = bool;
+      default = false;
+      example = true;
+      description = ''
+        Enable for users managed by an external identity provider like
+        Kanidm, LDAP, SSSD, etc. This option prevents Hjem from
+        associating hjem.users.<username> with users.users.<username>
+        allowing hjem-activate@<username>.service to dynamically resolve
+        network users and preventing config evaluation errors.
+
+        Make sure these users are resolvable BEFORE `hjem-activate@` services start.
+        This is already handled for Kanidm, consider opening a PR for other IDPs.
+
+        Hint: use UID for hjem.users.<username> if your IDP allows users
+        to change their own usernames.
+      '';
     };
 
     directory = mkOption {
@@ -261,6 +283,13 @@ in {
   config = {
     # for docs
     _module.args.name = lib.mkDefault "‹username›";
+
+    assertions = [
+      {
+        assertion = config.externalIdp -> config.packages == [];
+        message = "\"${config.user}\".packages must be empty when \"${config.user}\".externalIdp = true.\n";
+      }
+    ];
 
     environment = {
       sessionVariables = {

--- a/modules/finix/base.nix
+++ b/modules/finix/base.nix
@@ -125,17 +125,35 @@
             name,
             ...
           }: let
-            user = osConfig.users.users.${name};
+            # When an external identity provider is configured, user lookups are
+            # handled at runtime via NSS/PAM. The assertion below only requires
+            # that the OS entry or externalIdp for the user is present, not both.
+            hasExternalIdp = cfg.users.${name}.externalIdp;
+            osUserEntry = osConfig.users.users.${name} or null;
           in {
             assertions = [
               {
-                assertion = config.enable -> user.enable;
-                message = "Enabled Hjem user '${name}' must also be configured and enabled in NixOS.";
+                assertion = config.enable -> (osUserEntry != null && osUserEntry.enable) || hasExternalIdp;
+                message = ''
+                  Enabled Hjem user '${name}' must either exist and be enabled via
+                  users.users.${name}.enable, or have users.users.${name}.externalIdp
+                  active, relying on runtime lookup (e.g. services.kanidm.unix.enable).
+                '';
               }
             ];
 
-            user = mkDefault user.name;
-            directory = mkDefault user.home;
+            # When the OS entry exists, derive user/directory from it.
+            # Otherwise require explicit values from the hjem declaration.
+            user = mkDefault (
+              if osUserEntry != null
+              then osUserEntry.name
+              else name
+            );
+            directory = mkDefault (
+              if osUserEntry != null
+              then osUserEntry.home
+              else "${osConfig.users.defaultUserHome}/${name}"
+            );
             clobberFiles = mkDefault cfg.clobberByDefault;
           }
         )

--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -105,17 +105,35 @@
             name,
             ...
           }: let
-            user = osConfig.users.users.${name};
+            # When an external identity provider is configured, user lookups are
+            # handled at runtime via NSS/PAM. The assertion below only requires
+            # that the OS entry or externalIdp for the user is present, not both.
+            hasExternalIdp = cfg.users.${name}.externalIdp;
+            osUserEntry = osConfig.users.users.${name} or null;
           in {
             assertions = [
               {
-                assertion = config.enable -> user.enable;
-                message = "Enabled Hjem user '${name}' must also be configured and enabled in NixOS.";
+                assertion = config.enable -> (osUserEntry != null && osUserEntry.enable) || hasExternalIdp;
+                message = ''
+                  Enabled Hjem user '${name}' must either exist and be enabled via
+                  users.users.${name}.enable, or have users.users.${name}.externalIdp
+                  active, relying on runtime lookup (e.g. services.kanidm.unix.enable).
+                '';
               }
             ];
 
-            user = mkDefault user.name;
-            directory = mkDefault user.home;
+            # When the OS entry exists, derive user/directory from it.
+            # Otherwise require explicit values from the hjem declaration.
+            user = mkDefault (
+              if osUserEntry != null
+              then osUserEntry.name
+              else name
+            );
+            directory = mkDefault (
+              if osUserEntry != null
+              then osUserEntry.home
+              else "${osConfig.users.defaultUserHome}/${name}"
+            );
             clobberFiles = mkDefault cfg.clobberByDefault;
           })
         ]
@@ -195,6 +213,8 @@ in {
             unitConfig.RefuseManualStart = true;
           };
 
+          # If using external identity management, this must
+          # start after users are resolvable.
           "hjem-activate@" = {
             description = "Link files for %i from their manifest";
             enableStrictShellChecks = true;
@@ -204,7 +224,8 @@ in {
               Type = "oneshot";
             };
             requires = ["hjem-prepare.service"];
-            after = ["hjem-prepare.service"];
+            after = ["hjem-prepare.service" "kanidm-unixd.service"];
+            wants = ["kanidm-unixd.service"];
             scriptArgs = "%i";
             script = ''
               ${checkEnabledUsers}


### PR DESCRIPTION
Add support for resolving users at runtime with external identity management providers via `hjem.users.<username>.externalIdp` option (Fixes #183). This has been tested and implemented with Kanidm but should theoretically apply to any such as FreeIPA, LDAP, SSSD etc. so long as their respective services are active before `hjem-activate@`.

This PR is pretty straight forward, mostly modify assertions and docs for a better user experience as Hjem fits the external IDP use case really well already. `hjem.users.<username>.externalIdp` was only required because of the experimental `hjem.users.<username>.packages` -> `users.users.<username>.packages` mapping. If that didn't exist this implementation could be handled automatically without adding an extra option.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

If your pull request aims to fix an open issue or a  bug, please also link the relevant issue below
this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside this
comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[CONTRIBUTING]: ../CONTRIBUTING.md
[unit tests]: ../tests

- [x] My changes fit the guidelines found in [CONTRIBUTING] guide
- [x] I have tested, and self-reviewed my code
- [ ] The [unit tests] for Hjem pass (`nix flake check`/`nix-build -A checks`)
- Style and consistency
  - [x] I formatted all relevant code (`nix fmt`/`nix run -f . formatter`)
  - [x] My changes are consistent with the rest of the codebase
  - [x] My commit messages fit the guidelines found in [CONTRIBUTING]
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have included a section in the documentation
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/feel-co/hjem/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
